### PR TITLE
Fix setup.py for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ requirements = [
     'scikit-allel',
     'pandas',
     'numpy',
-    'python',
     'multiprocess',
     'scipy',
     'numcodecs'


### PR DESCRIPTION
`'python'` shouldn't be in the `requirements` list: that list should only contain Python packages