### PR TITLE
feat: Support samples of arbitrary ploidy

### DIFF
--- a/pixy/calc.py
+++ b/pixy/calc.py
@@ -195,6 +195,11 @@ def calc_fst(
 
     # WC 84
     if fst_type is FSTEstimator.WC:
+        if gt_array_fst.ploidy != 2:
+            raise NotImplementedError(
+                "`pixy` does not currently support calculation "
+                "of Weir-Cockerham FST in non-diploid genomes"
+            )
         a: NDArray
         b: NDArray
         c: NDArray

--- a/stubs/allel.pyi
+++ b/stubs/allel.pyi
@@ -179,3 +179,20 @@ def read_vcf(
     log: Optional[TextIO] = None,
 ) -> Optional[Dict[str, NDArray]]: ...
 def read_vcf_headers(input: Any) -> VCFHeaders: ...
+
+####################################################################################################
+# allel.mean_pairwise_difference
+# https://github.com/cggh/scikit-allel/blob/master/allel/allel/stats/diversity.py
+####################################################################################################
+def mean_pairwise_difference(
+    ac: NDArray,
+    an: NDArray,
+    fill: float = np.nan,
+) -> NDArray: ...
+def mean_pairwise_difference_between(
+    ac1: NDArray,
+    ac2: NDArray,
+    an1: Optional[NDArray] = None,
+    an2: Optional[NDArray] = None,
+    fill: float = np.nan,
+) -> NDArray: ...

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,6 +1,10 @@
+import numpy as np
 import pytest
+from allel import AlleleCountsArray
 from allel import GenotypeArray
 from allel import hudson_fst
+from allel import mean_pairwise_difference
+from allel import mean_pairwise_difference_between
 from allel import weir_cockerham_fst
 
 from pixy.calc import calc_dxy
@@ -123,6 +127,157 @@ def test_calc_dxy_single_locus() -> None:
     assert result.total_comps == expected_comps
     assert result.total_missing == 0
     assert result.avg_dxy == pytest.approx(expected_diffs / expected_comps)
+
+
+def test_calc_pi_arbitrary_ploidy() -> None:
+    """
+    Test that our Pi calculation is valid in the context of arbitrary ploidy.
+
+    This test evaluates   at one site in a tetraploid context.
+    Importantly, there are NO missing genotypes here.
+    This test asserts the following:
+      - the `pixy` calculation of pi matches the scikit-allel implementation
+          (which is sufficient with no missing sites)
+      - the pairwise comparison short-cut is valid for a given gt_array of arbitrary ploidy
+      - the `pixy` calculation matches the publication
+    """
+    gt_array = GenotypeArray([
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+    ])  # tetraploid
+
+    # sanity
+    assert gt_array.n_samples == 3
+    assert gt_array.n_variants == 1
+    assert gt_array.ploidy == 4
+    result: PiResult = calc_pi(gt_array)
+
+    # Section 1.1 of Korunes & Samuk
+    # https://pmc.ncbi.nlm.nih.gov/articles/PMC8044049/
+    expected_diffs = 9 * 3  # total 9 zeros * 3 ones
+    expected_comps = 66  # 12 choose 2
+    assert result.total_diffs == expected_diffs
+    assert result.total_comps == expected_comps
+    assert result.total_missing == 0
+    assert result.avg_pi == pytest.approx(expected_diffs / expected_comps)
+
+    # assert that `pixy` matches `scikit-allel` in the context of no missing sites
+    allele_counts: AlleleCountsArray = gt_array.count_alleles()  # [9,3]
+    assert result.avg_pi == pytest.approx(
+        mean_pairwise_difference(ac=allele_counts, an=np.sum(allele_counts, axis=1))
+    )
+
+
+def test_calc_dxy_arbitrary_ploidy() -> None:
+    """
+    Test that our Dxy calculation is valid in the context of arbitrary ploidy.
+
+    Currently this test looks at one site in a tetraploid context only.
+    In the future we can parameterize `GenotypeArray` inputs.
+    Importantly, there are NO missing genotypes here.
+    This test asserts the following:
+      - the `pixy` calculation matches a brute-force approach for arbitrary ploidy
+      - the pairwise comparison short-cut is valid for given gt_arrays of arbitrary ploidy
+      - the `pixy` calculation  matches the publication
+    """
+    pop1_gt_array = GenotypeArray([
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+    ])  # population 1/site 1
+
+    pop2_gt_array = GenotypeArray([
+        [[0, 1, 0, 0], [0, 1, 0, 0], [1, 1, 1, 1]],  # population 2/site 1
+    ])
+
+    # sanity
+    assert pop1_gt_array.n_samples == pop2_gt_array.n_samples == 3
+    assert pop1_gt_array.n_variants == pop2_gt_array.n_variants == 1
+    assert pop1_gt_array.ploidy == pop2_gt_array.ploidy == 4
+    result: DxyResult = calc_dxy(pop1_gt_array=pop1_gt_array, pop2_gt_array=pop2_gt_array)
+    expected_diffs = (9 * 6) + (3 * 6)
+    expected_comps = 144  # 12 alleles in each population
+    assert result.total_diffs == expected_diffs
+    assert result.total_comps == expected_comps
+    assert result.total_missing == 0
+    assert result.avg_dxy == pytest.approx(expected_diffs / expected_comps)
+
+    # scikit-allel provides support for dxy calculation
+    # (but unlike pixy does not support missing sites)
+    # double-check that we match their implementation
+    allel_dxy = mean_pairwise_difference_between(
+        ac1=pop1_gt_array.count_alleles(),
+        ac2=pop2_gt_array.count_alleles(),
+    )
+    assert result.avg_dxy == pytest.approx(allel_dxy)
+
+
+def test_calc_fst_hudson_arbitrary_ploidy() -> None:
+    """
+    Compare FST calculation (Hudson) to the `scikit-allel` implementation.
+
+    The WC FST calculation for arbitrary ploidy is not currently supported within `scikit-allel`
+    and thus is not tested here.
+
+    """
+    # scikit-allel's implementation accepts one array for each population
+    pop1_gt_array = GenotypeArray([
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+        [[0, 1, 0, 0], [0, 1, 0, 0], [1, 1, 1, 1]],  # population 2/site 1
+    ])  # population 1/site 1
+
+    pop2_gt_array = GenotypeArray([
+        [[0, 1, 0, 0], [0, 1, 0, 0], [1, 1, 1, 1]],  # population 2/site 1
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+    ])
+
+    num, den = hudson_fst(
+        ac1=pop1_gt_array.count_alleles(),
+        ac2=pop2_gt_array.count_alleles(),
+    )
+
+    expected_fst = num.sum() / den.sum()
+
+    # `calc_fst` accepts an aggregate array with all populations combined
+    combined_gt_array = pop1_gt_array.concatenate(pop2_gt_array, axis=1)
+    assert combined_gt_array.n_samples == pop1_gt_array.n_samples + pop2_gt_array.n_samples
+    assert combined_gt_array.n_variants == pop1_gt_array.n_variants == pop2_gt_array.n_variants
+
+    result: FstResult = calc_fst(
+        gt_array_fst=combined_gt_array,
+        fst_pop_indicies=[
+            [0, 1, 2],  # population 1
+            [3, 4, 5],  # population 2
+        ],
+        fst_type=FSTEstimator.HUDSON,
+    )
+
+    assert result.fst == pytest.approx(expected_fst)
+    assert result.a == pytest.approx(num.sum())
+    assert result.b == pytest.approx(den.sum())
+    assert result.c == 0
+    assert result.n_sites == combined_gt_array.n_variants
+
+
+def test_calc_fst_wc_arbitrary_ploidy_raises() -> None:
+    """Ensure we raise a `NotImplementedError` if FST_WC is requested in non-diploid genomes."""
+    pop1_gt_array = GenotypeArray([
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+        [[0, 1, 0, 0], [0, 1, 0, 0], [1, 1, 1, 1]],  # population 2/site 1
+    ])  # population 1/site 1
+
+    pop2_gt_array = GenotypeArray([
+        [[0, 1, 0, 0], [0, 1, 0, 0], [1, 1, 1, 1]],  # population 2/site 1
+        [[0, 0, 0, 0], [0, 1, 0, 0], [1, 1, 0, 0]],
+    ])
+    combined_gt_array = pop1_gt_array.concatenate(pop2_gt_array, axis=1)
+
+    with pytest.raises(NotImplementedError):
+        calc_fst(
+            gt_array_fst=combined_gt_array,
+            fst_pop_indicies=[
+                [0, 1, 2],  # population 1
+                [3, 4, 5],  # population 2
+            ],
+            fst_type=FSTEstimator.WC,
+        )
 
 
 def test_calc_fst_hudson() -> None:


### PR DESCRIPTION
## Summary

This PR adds support for the calculation of `pi`, `dxy`, and `Hudson FST` in the context of arbitrary ploidy. `Weir-Cockerham FST` is not yet included, as `scikit-allel` does not have native support for that calculation at this time. Mixed ploidy is not yet supported.

## Changed
* `calc_pi` and `calc_dxy` functions were updated to support arbitrary ploidy
* Unit tests were added to verify changes in the context of tetraploidy
* Users are explicitly prohibited from requesting the Weir-Cockerham FST statistic in the context of non-diploid organisms
