### PR TITLE
refactor: use logging instead of print statements

### DIFF
--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -500,7 +500,7 @@ def test_pixy_main_valid_inputs(
     expected_outputs: Path,
     ag1000_pop_path: Path,
     ag1000_vcf_path: Path,
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Given specific input data, assert that outputs do not change.
@@ -508,6 +508,7 @@ def test_pixy_main_valid_inputs(
     Uses `filecmp` library to compare 2 files without opening them and reading line-by-line.
     `filecmp.cmp` returns True if 2 files are equal.
     """
+    caplog.set_level(logging.INFO)
     run_pixy_helper(
         pixy_out_dir=pixy_out_dir,
         stats=["pi", "fst", "dxy"],
@@ -515,8 +516,10 @@ def test_pixy_main_valid_inputs(
         vcf_path=ag1000_vcf_path,
         populations_path=ag1000_pop_path,
     )
-    captured = capsys.readouterr()
-    assert "Data set contains 2 population(s), 2 chromosome(s), and 36 sample(s)" in captured.out
+    assert (
+        "[pixy] Data set contains 2 populations, 2 chromosome(s), and 36 sample(s)"
+        in caplog.messages
+    )
 
     expected_out_files: List[Path] = [
         Path("pixy_dxy.txt"),


### PR DESCRIPTION
# Summary
This PR replaces print statements with a structured, more conventional logging mechanism across `pixy` modules.

# Changed
* `pixy` now uses the standard `logging` library in Python instead of `print` statements to capture run information. 
* Corresponding `pixy` tests have been updated to check the `logging` output instead of checking standard out.