### PR TITLE
refactor: supply boolean args to `pixy`

### DIFF
--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -210,24 +210,33 @@ def main() -> None:  # noqa: C901
         ),
         required=False,
     )
-    optional.add_argument(
-        "--include_multiallelic_snps",
-        choices=["yes", "no"],
-        default="no",
-        help=("Multiallelic SNPs within the VCF will be included during calculation.(default=no)."),
-        required=False,
-    )
-    optional.add_argument(
-        "--bypass_invariant_check",
-        choices=["yes", "no"],
-        default="no",
-        help=(
-            "Allow computation of stats without invariant sites (default=no).\n"
-            "Will result in wildly incorrect estimates most of the time.\n"
-            "Use with extreme caution!"
+    (
+        optional.add_argument(
+            "--include_multiallelic_snps",
+            action="store_true",
+            default=False,
+            help=(
+                "Multiallelic SNPs within the VCF will be included "
+                "during calculation.(default=False)."
+            ),
+            required=False,
         ),
-        required=False,
     )
+
+    (
+        optional.add_argument(
+            "--bypass_invariant_check",
+            action="store_true",
+            default=False,
+            help=(
+                "Allow computation of stats without invariant sites (default=False).\n"
+                "Will result in wildly incorrect estimates most of the time.\n"
+                "Use with extreme caution!"
+            ),
+            required=False,
+        ),
+    )
+
     optional.add_argument(
         "--version",
         action="version",

--- a/pixy/args_validation.py
+++ b/pixy/args_validation.py
@@ -509,7 +509,7 @@ def check_and_validate_args(  # noqa: C901
     # a very basic check: just looks for at least one invariant site in the alt field
     logger.info("Checking for invariant sites...")
     check_message = "OK"
-    bypass_invariant_check: bool = args.bypass_invariant_check == "yes"
+    bypass_invariant_check: bool = args.bypass_invariant_check
     if not bypass_invariant_check:
         alt_list = (
             subprocess.check_output(
@@ -537,7 +537,7 @@ def check_and_validate_args(  # noqa: C901
     else:
         if not (len(args.stats) == 1 and (args.stats[0] == "fst")):
             logger.warning(
-                "EXTREME WARNING: --bypass_invariant_check is set to 'yes'. Note that a "
+                "EXTREME WARNING: --bypass_invariant_check is set to True. Note that a "
                 "lack of invariant sites will result in incorrect estimates."
             )
 
@@ -642,7 +642,7 @@ def check_and_validate_args(  # noqa: C901
             "defined in the population file."
         )
 
-    include_multiallelic_snps: bool = args.include_multiallelic_snps == "yes"
+    include_multiallelic_snps: bool = args.include_multiallelic_snps
 
     logger.info("All initial checks passed!")
     stats: List[PixyStat] = [PixyStat[stat.upper()] for stat in args.stats]

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -312,7 +312,7 @@ def read_and_filter_genotypes(
     # a string representation of the target region of the current window
     window_region = chromosome + ":" + str(window_pos_1) + "-" + str(window_pos_2)
 
-    include_multiallelic_snps: bool = args.include_multiallelic_snps == "yes"
+    include_multiallelic_snps: bool = args.include_multiallelic_snps
 
     # read in data from the source VCF for the current window
     callset = allel.read_vcf(
@@ -691,7 +691,7 @@ def check_and_validate_args(  # noqa: C901
     # a very basic check: just looks for at least one invariant site in the alt field
     logger.info("[pixy] Checking for invariant sites...")
 
-    if args.bypass_invariant_check == "no":
+    if not args.bypass_invariant_check:
         alt_list = (
             subprocess.check_output(
                 "gunzip -c "
@@ -706,19 +706,19 @@ def check_and_validate_args(  # noqa: C901
             raise Exception(
                 "[pixy] ERROR: the provided VCF appears to contain no invariant sites "
                 '(ALT = "."). '
-                "This check can be bypassed via --bypass_invariant_check 'yes'."
+                "This check can be bypassed via --bypass_invariant_check"
             )
         if "." in alt_list and len(alt_list) == 1:
             logger.warning(
                 "[pixy] WARNING: the provided VCF appears to contain no variable sites in the "
                 "first 100 000 sites. It may have been filtered incorrectly, or genetic diversity "
                 "may be extremely low. "
-                "This warning can be suppressed via --bypass_invariant_check 'yes'.'"
+                "This warning can be suppressed via --bypass_invariant_check"
             )
     else:
         if not (len(args.stats) == 1 and (args.stats[0] == "fst")):
             logger.warning(
-                "[pixy] EXTREME WARNING: --bypass_invariant_check is set to 'yes'. Note that a "
+                "[pixy] EXTREME WARNING: --bypass_invariant_check is set to True. Note that a "
                 "lack of invariant sites will result in incorrect estimates."
             )
 

--- a/tests/args_validation/test_args_validation.py
+++ b/tests/args_validation/test_args_validation.py
@@ -7,7 +7,7 @@ from pixy.args_validation import PixyArgs
 from pixy.args_validation import check_and_validate_args
 
 
-@pytest.mark.parametrize("bypass_variant_check", ["yes", "no"])
+@pytest.mark.parametrize("bypass_variant_check", [True, False])
 def test_check_and_validate_args(
     ag1000_vcf_path: Path,
     ag1000_pop_path: Path,
@@ -35,7 +35,7 @@ def test_check_and_validate_args(
     args.sites_file = None
 
     generated_pixy_args: PixyArgs = check_and_validate_args(args)
-    if bypass_variant_check == "yes":
-        assert generated_pixy_args.bypass_invariant_check is True
+    if bypass_variant_check:
+        assert generated_pixy_args.bypass_invariant_check
     else:
-        assert generated_pixy_args.bypass_invariant_check is False
+        assert not generated_pixy_args.bypass_invariant_check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,8 @@ def run_pixy_helper(  # noqa: C901
     stats: List[str],
     vcf_path: Path,
     populations_path: Optional[Path] = None,
-    bypass_invariant_check: str = "no",
+    include_multiallelic_snps: bool = False,
+    bypass_invariant_check: bool = False,
     window_size: Optional[int] = None,
     interval_start: Optional[int] = None,
     interval_end: Optional[int] = None,
@@ -178,8 +179,6 @@ def run_pixy_helper(  # noqa: C901
         f"{pixy_out_dir}",
         "--chromosomes",
         f"{chromosomes}",
-        "--bypass_invariant_check",
-        f"{bypass_invariant_check}",
     ]
     if window_size is not None:
         test_args.extend((["--window_size", f"{window_size}"]))
@@ -215,6 +214,13 @@ def run_pixy_helper(  # noqa: C901
 
     if fst_type is not None:
         test_args.extend((["--fst_type", f"{fst_type}"]))
+
+    if bypass_invariant_check:
+        test_args.extend(["--bypass_invariant_check"])
+
+    if include_multiallelic_snps:
+        test_args.extend(["--include_multiallelic_snps"])
+    print(f"test_args: {test_args}")
     with patch.object(sys, "argv", test_args):
         main()
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -376,9 +376,9 @@ def test_bypass_invariant_check_warns(
         window_size=10000,
         vcf_path=ag1000_vcf_path,
         populations_path=ag1000_pop_path,
-        bypass_invariant_check="yes",
+        bypass_invariant_check=True,
     )
-    assert "EXTREME WARNING: --bypass_invariant_check is set to 'yes'" in caplog.text
+    assert "EXTREME WARNING: --bypass_invariant_check is set to True" in caplog.text
 
 
 ################################################################################


### PR DESCRIPTION
# Summary
This PR sets `--bypass_invariant_check` and `--include_multiallelic_snps` to more conventional boolean arguments.

# Changed
* `pixy` now accepts more conventional boolean CLI arguments instead of a "yes/no" option.
* Tests have been updated accordingly.
* **This is a breaking change**: any scripts that try to use the current paradigm (`--bypass_invariant_check yes` instead of just `--bypass_invariant_check`) will no longer work.