### PR TITLE
feat: Feature Expansion - Add Watterson's Theta and Tajima's D estimators to pixy (#101)

### DIFF
--- a/pixy/enums.py
+++ b/pixy/enums.py
@@ -12,12 +12,15 @@ class PixyStat(Enum):
         DXY: a measure of genetic diversity _between_ populations
         FST: the "fixation index"; represents a subpopulation-specific genetic variance
             relative to the total genetic variance
-
+        TAJIMA_D: a measure of non-neutral evolution in a population
+        WATTERSON_THETA: an estimator of genetic diversity
     """
 
     PI = "pi"
     DXY = "dxy"
     FST = "fst"
+    TAJIMA_D = "tajima_d"
+    WATTERSON_THETA = "watterson_theta"
 
     def __str__(self) -> str:
         return self.value

--- a/pixy/models.py
+++ b/pixy/models.py
@@ -38,8 +38,25 @@ class PixyTempResult:
             - total_comparisons)
 
     `population_1` and `population_2` will both be populated for "dxy" and "fst" results.
-    `population_2` will be "NA" when reporting "pi" results.
+    `population_2` will be "NA" when reporting "pi", "watterson_theta", and "tajima_d" results.
 
+    This object is overloaded so that all `pixy` stats can leverage one dataclass to hold temporary
+    results.
+
+    In the case of Tajima's D, `tajima_d` is stored in the `calculated_stat`
+    field. `num_sites` is stored in the `shared_sites_with_alleles` field.
+    `raw_pi` is stored in the `total_differences` field.
+    `watterson_theta` is stored in the `total_comparisons` field.
+    `d_stdev` is stored in the `total_missing` field.
+
+    This object is overloaded so that all `pixy` stats can leverage one dataclass to hold temporary
+    results.
+
+    In the case of Watterson's Theta, `avg_watterson_theta` is stored in the `calculated_stat`
+    field. `num_sites` is stored in the `shared_sites_with_alleles` field.
+    `raw_watterson_theta` is stored in the `total_differences` field.
+    `num_variant_sites` is stored in the `total_comparisons` field.
+    `num_weighted_sites` is stored in the `total_missing` field.
     """
 
     pixy_stat: PixyStat
@@ -131,3 +148,66 @@ class FstResult:
     def empty(cls) -> "FstResult":
         """An empty FstResult, with all fields set to NA."""
         return cls(fst="NA", a="NA", b="NA", c="NA", n_sites=0)
+
+
+@dataclass
+class TajimaDResult:
+    """
+    A result from calculating Tajima's D.
+
+    Tajima's D is an indicator of the difference between the observed and expected number of
+    polymorphisms in a given population. Both Watterson's Theta and pi are components of the
+    calculation.
+
+    Attributes:
+        tajima_d: the calculated Tajima's D ("NA" if unable to be calculated)
+        num_sites: number of sites with an observed genotype
+        raw_pi: the raw nucleotide diversity (the sum of the mean_pairwise_difference)
+        watterson_theta: the calculation of Watterson's theta that includes missing genotypes
+        d_stdev: the denominator of Tajima's D (standard deviation of the covariance between the
+            calculated raw pi and watterson_theta)
+    """
+
+    tajima_d: Union[float, NA]
+    num_sites: int
+    raw_pi: Union[float, NA]
+    watterson_theta: Union[float, NA]
+    d_stdev: Union[float, NA]
+
+    @classmethod
+    def empty(cls) -> "TajimaDResult":
+        """An empty `TajimaDResult`, with all fields set to NA."""
+        return cls(tajima_d="NA", num_sites=0, raw_pi="NA", watterson_theta="NA", d_stdev="NA")
+
+
+@dataclass
+class WattersonThetaResult:
+    """
+    A result from calculating Watterson's Theta.
+
+    Alleles are counted and variant alleles are extracted. The number of sites represents the count
+    of sites with more than zero alleles. The number of variant sites represents the count of sites
+    where the variant count is not 0.
+
+    The avg_theta represents the raw Watterson's Theta scaled by number of sites ("windowed").
+
+    Attributes:
+        num_sites: number of sites with more than zero alleles
+        num_var_sites: number of variant sites
+        avg_theta: calculated as `raw_theta`/`weighted_sites`
+        raw_theta: per-site (unscaled) Watterson's Theta
+        num_weighted_sites: number of sites weighted by how many genotypes are missing in each site
+    """
+
+    num_sites: int
+    num_var_sites: int
+    avg_theta: Union[float, NA]
+    raw_theta: Union[float, NA]
+    num_weighted_sites: Union[float, NA]
+
+    @classmethod
+    def empty(cls) -> "WattersonThetaResult":
+        """An empty `WattersonThetaResult`, with all fields set to NA."""
+        return cls(
+            num_sites=0, num_var_sites=0, avg_theta="NA", raw_theta="NA", num_weighted_sites="NA"
+        )

--- a/stubs/allel.pyi
+++ b/stubs/allel.pyi
@@ -56,6 +56,7 @@ class AlleleCountsArray(NumpyArrayWrapper):
     def __getitem__(self, item: Any) -> Any: ...
     def to_frequencies(self, fill: float = np.nan) -> NDArray: ...
     def max_allele(self) -> NDArray: ...
+    def count_segregating(self) -> int: ...
 
 class GenotypeArray(Genotypes):
     def __init__(
@@ -187,7 +188,7 @@ def read_vcf_headers(input: Any) -> VCFHeaders: ...
 ####################################################################################################
 def mean_pairwise_difference(
     ac: NDArray,
-    an: NDArray,
+    an: Optional[NDArray] = None,
     fill: float = np.nan,
 ) -> NDArray: ...
 def mean_pairwise_difference_between(
@@ -197,3 +198,27 @@ def mean_pairwise_difference_between(
     an2: Optional[NDArray] = None,
     fill: float = np.nan,
 ) -> NDArray: ...
+
+####################################################################################################
+# allel.watterson_theta
+# https://github.com/cggh/scikit-allel/blob/master/allel/allel/stats/diversity.py
+####################################################################################################
+def watterson_theta(
+    pos: List[int],
+    ac: NDArray,
+    start: Optional[int] = None,
+    stop: Optional[int] = None,
+    is_accessible: Optional[List[bool]] = None,
+) -> float: ...
+
+####################################################################################################
+# allel.tajima_d
+# https://github.com/cggh/scikit-allel/blob/master/allel/allel/stats/diversity.py
+####################################################################################################
+def tajima_d(
+    ac: NDArray,
+    pos: Optional[List[int]] = None,
+    start: Optional[int] = None,
+    stop: Optional[int] = None,
+    min_sites: Optional[int] = None,
+) -> float: ...

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -456,6 +456,12 @@ def test_pixy_csi_index(
         ),  # non-default prefix
         ("test", ["pi"], ["test_pi.txt"]),  # only pi
         ("test", ["pi", "fst"], ["test_pi.txt", "test_fst.txt"]),  # both pi and fst
+        ("test", ["pi", "tajima_d"], ["test_pi.txt", "test_tajima_d.txt"]),  # include tajima_d
+        (
+            "test",
+            ["pi", "watterson_theta"],
+            ["test_pi.txt", "test_watterson_theta.txt"],
+        ),  # include watterson_theta
     ],
 )
 def test_pixy_output_creation(
@@ -480,7 +486,7 @@ def test_pixy_output_creation(
         full_path: Path = pixy_out_dir / Path(file)
         assert full_path.exists()
 
-    all_possible_files: List[str] = ["pi", "fst", "dxy"]
+    all_possible_files: List[str] = ["pi", "fst", "dxy", "watterson_theta", "tajima_d"]
     # make sure we do not produce files we did not ask for
     unexpected_files: List[str] = list(set(all_possible_files) - set(stats_requested))
     for file in unexpected_files:


### PR DESCRIPTION
## Summary

This PR incorporates Nick Bailey's code for calculating Tajima's D and Watterson's Theta in `pixy`, in the context of missing data. 

## Changed
* add Tajima's D statistic to `pixy`, with multi-allelic support
* add Watterson's Theta estimator to `pixy`, with multi-allelic support
* add unit tests for calculation of both summary statistics 