### PR TITLE
change mp queue assertion to use BaseProxy

### DIFF
--- a/debug/debug_template.sh
+++ b/debug/debug_template.sh
@@ -1,0 +1,18 @@
+# template for debugging user submitted vcfs and pop files
+# tbd: context specificity (e.g. ignore bedfile if not present)
+
+
+pixy="python pixy/__main__.py"
+data_folder="tests/main/data"
+
+vcf_path="${data_folder}/ag1000_pixy_invariant_test.vcf.gz"
+pop_path="${data_folder}/ag1000_populations_file.txt"
+
+$pixy --debug \
+--stats pi --vcf $vcf_path  \
+--populations $pop_path \
+--window_size 100000 \
+--n_cores 4 \
+--output_folder . \
+--output_prefix all_pi \
+--bypass_invariant_check

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -21,6 +21,8 @@ from allel import GenotypeArray
 from allel import GenotypeVector
 from allel import SortedIndex
 from multiprocess import Queue
+from multiprocess import queues
+from multiprocess.managers import BaseProxy
 from numpy.typing import NDArray
 
 from pixy.args_validation import get_chrom_list
@@ -620,7 +622,7 @@ def compute_summary_stats(  # noqa: C901
     if pixy_output:
         temp_pixy_content: str = "\n".join(f"{result}" for result in pixy_output)
         if args.n_cores > 1:
-            assert isinstance(q, Queue), "q should be a Queue object when multiprocessing"
+            assert isinstance(q, (queues.Queue, BaseProxy)), "q should be a Queue object when multiprocessing"
             q.put(temp_pixy_content)
         elif args.n_cores == 1:
             outfile = open(temp_file, "a")


### PR DESCRIPTION
Changes the isInstance assertion for multiprocess queues in pixy core.py to use the correct type from multiprocess.managers BaseProxy. Addresses #142.