### PR TITLE
fix for watterson's theta for haploids

### DIFF
--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -40,7 +40,7 @@ def main() -> None:  # noqa: C901
         "pixy: unbiased estimates of pi, dxy, fst, Watterson's Theta, and Tajima's D from "
         "VCFs with invariant sites"
     )
-    version = "2.0.0.beta12"
+    version = "2.0.0.beta13"
     citation = (
         "Korunes, KL and K Samuk. "
         "pixy: Unbiased estimation of nucleotide diversity and divergence in the presence of "

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -609,7 +609,8 @@ def compute_summary_stats(  # noqa: C901
                     # assert gt_region is not None, "genotype array is None"
                     # assert callset_is_none is not None, "callset is empty"
                     # subset the window for the individuals in each population
-                    gt_pop = GenotypeArray(gt_region.take(popindices[pop], axis=1))
+                    gt_pop = gt_region.take(popindices[pop], axis=1)
+
                     # if the population specific window for this region is empty, report it as such
                     if len(gt_pop) == 0:
                         watterson_result = WattersonThetaResult.empty()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ["scikit-allel", "pandas", "numpy", "multiprocess", "scipy", "num
 
 setup(
     name="pixy",
-    version="2.0.0.beta8",
+    version="2.0.0.beta13",
     packages=["pixy"],
     entry_points={"console_scripts": ["pixy=pixy.__main__:main"]},
     url="https://github.com/ksamuk/pixy",

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -431,7 +431,7 @@ def test_pixy_csi_index(
         generated_data_path: Path = pixy_out_dir / file
         exp_data_path: Path = expected_outputs / "baseline" / file
         assert generated_data_path.exists()
-        #shutil.copy(generated_data_path, exp_data_path)
+        # shutil.copy(generated_data_path, exp_data_path)
         assert_files_are_consistent(generated_data_path, exp_data_path)
 
 
@@ -591,7 +591,7 @@ def test_pixy_limited_sites(
         exp_data_path: Path = expected_outputs / output_prefix / file
 
         assert generated_data_path.exists()
-        #shutil.copy(generated_data_path, exp_data_path)
+        # shutil.copy(generated_data_path, exp_data_path)
         assert_files_are_consistent(generated_data_path, exp_data_path)
 
 
@@ -632,7 +632,7 @@ def test_pixy_limited_bed_file(
         exp_data_path: Path = expected_outputs / "limited_bed" / file
 
         assert generated_data_path.exists()
-        #shutil.copy(generated_data_path, exp_data_path)
+        # shutil.copy(generated_data_path, exp_data_path)
         assert_files_are_consistent(generated_data_path, exp_data_path)
 
 
@@ -683,7 +683,7 @@ def test_pixy_limited_sites_bed(
     for file in expected_out_files:
         generated_data_path: Path = pixy_out_dir / file
         exp_data_path: Path = expected_outputs / "limited_sites_and_bed" / file
-        #assert generated_data_path.exists()
+        # assert generated_data_path.exists()
         assert_files_are_consistent(generated_data_path, exp_data_path)
 
 
@@ -719,5 +719,5 @@ def test_pixy_hudson_fst(
         generated_data_path: Path = pixy_out_dir / file
         exp_data_path: Path = expected_outputs / "hudson_fst" / file
         assert generated_data_path.exists()
-        #shutil.copy(generated_data_path, exp_data_path)
+        # shutil.copy(generated_data_path, exp_data_path)
         assert_files_are_consistent(generated_data_path, exp_data_path)


### PR DESCRIPTION
- This fixes the indexing of HaplotypeArrays when computing Watterson's theta for haploids, addressing #173 