### PR TITLE
Fix for haploid computation of dxy/fst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ debug/*.vcf*
 .vscode/*
 pixy_tmp*
 debug_temp*
+debug/*
 
 __pycache__/
 .coverage

--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -40,7 +40,7 @@ def main() -> None:  # noqa: C901
         "pixy: unbiased estimates of pi, dxy, fst, Watterson's Theta, and Tajima's D from "
         "VCFs with invariant sites"
     )
-    version = "2.0.0.beta13"
+    version = "2.0.0.beta14"
     citation = (
         "Korunes, KL and K Samuk. "
         "pixy: Unbiased estimation of nucleotide diversity and divergence in the presence of "

--- a/pixy/args_validation.py
+++ b/pixy/args_validation.py
@@ -295,6 +295,13 @@ def validate_vcf_path(vcf_path: str) -> None:
             "The vcf is not indexed. Please either use `tabix` or `bcftools` to"
             "produce a `.tbi` or `.csi` index."
         )
+    
+    # update the date of the index 
+    # this apparently resolves issues of indexes being older than vcfs in some pipelines
+    if os.path.exists(vcf_path + ".tbi"):
+        subprocess.run(["touch", "-c", str(vcf_path + ".tbi")])
+    else:
+        subprocess.run(["touch", "-c", str(vcf_path + ".csi")])
 
 
 def validate_output_path(output_folder: str, output_prefix: str) -> Tuple[str, str]:

--- a/pixy/calc.py
+++ b/pixy/calc.py
@@ -160,8 +160,19 @@ def calc_dxy(pop1_gt_array: GenotypeArray, pop2_gt_array: GenotypeArray) -> DxyR
     pop2_allele_counts: AlleleCountsArray = pop2_gt_array.count_alleles()
 
     # the number of (haploid) samples in each population
-    pop1_n_haps: int = pop1_gt_array.n_samples * pop1_gt_array.ploidy
-    pop2_n_haps: int = pop2_gt_array.n_samples * pop2_gt_array.ploidy
+    # haplotype arrays use n_haplotypes instead of n_samples * ploidy
+
+    if isinstance(pop1_gt_array, allel.model.ndarray.HaplotypeArray):
+        pop1_n_haps: int = pop1_gt_array.n_haplotypes
+    else:
+        pop1_n_haps: int = pop1_gt_array.n_samples * pop1_gt_array.ploidy
+
+    if isinstance(pop2_gt_array, allel.model.ndarray.HaplotypeArray):
+        pop2_n_haps: int = pop2_gt_array.n_haplotypes
+    else:
+        pop2_n_haps: int = pop2_gt_array.n_samples * pop2_gt_array.ploidy
+
+    
 
     # the total number of differences between populations summed across all sites
     persite_diffs: NDArray = np.zeros(n_sites)

--- a/pixy/stats/summary.py
+++ b/pixy/stats/summary.py
@@ -13,6 +13,7 @@ from allel import AlleleCountsArray
 from allel import GenotypeArray
 from allel import GenotypeVector
 from allel import SortedIndex
+from allel import HaplotypeArray
 from allel import windowed_hudson_fst
 from allel import windowed_weir_cockerham_fst
 from numpy.typing import NDArray
@@ -442,14 +443,21 @@ def _compute_individual_fst_for_pair(
     fst_window_size = window_pos_2 - window_pos_1
 
     if fst_type is FSTEstimator.WC:
-        fst, window_positions, n_snps = windowed_weir_cockerham_fst(
-            pos_array_fst,
-            gt_array_fst,
-            subpops=fst_pop_indicies,
-            size=fst_window_size,
-            start=window_pos_1,
-            stop=window_pos_2,
-        )
+        if isinstance(gt_array_fst, HaplotypeArray):
+            raise NotImplementedError(
+                "`pixy` does not currently support calculation "
+                "of Weir-Cockerham FST in non-diploid genomes. "
+                "Use --fst_type hudson to resolve this error."
+            )
+        else:
+            fst, window_positions, n_snps = windowed_weir_cockerham_fst(
+                pos_array_fst,
+                gt_array_fst,
+                subpops=fst_pop_indicies,
+                size=fst_window_size,
+                start=window_pos_1,
+                stop=window_pos_2,
+            )
 
     elif fst_type is FSTEstimator.HUDSON:
         ac1 = gt_array_fst.count_alleles(subpop=fst_pop_indicies[0])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ["scikit-allel", "pandas", "numpy", "multiprocess", "scipy", "num
 
 setup(
     name="pixy",
-    version="2.0.0.beta13",
+    version="2.0.0.beta14",
     packages=["pixy"],
     entry_points={"console_scripts": ["pixy=pixy.__main__:main"]},
     url="https://github.com/ksamuk/pixy",


### PR DESCRIPTION
- Fixes computation of sample numbers when computing dxy for haploid datasets. Resolves: #175  
- Includes warning for computation of WC FST for haploids (Hudson's works for haploids!)
- Added automatic updating of index dates via `touch`. Resolves: #176 