### PR TITLE
Add typing-extensions dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ numpy        = "^1.24.4"
 pandas       = "^1.5.3"
 scikit-allel = "^1.3.7"
 scipy        = "^1.10.1"
+typing-extensions = "*"
 
 [tool.poetry.group.dev.dependencies]
 mypy        = "^1.13.0"


### PR DESCRIPTION
Add `typing-extensions` to pyproject.toml so `pixy --help` runs correctly.