### PR TITLE
Fix #185 and #183

### DIFF
--- a/pixy/args_validation.py
+++ b/pixy/args_validation.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import uuid
+import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -526,7 +527,9 @@ def check_and_validate_args(  # noqa: C901
     output_prefix = output_folder + args.output_prefix
 
     # get vcf header info
-    vcf_headers = allel.read_vcf_headers(vcf_path)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, module="allel")
+        vcf_headers = allel.read_vcf_headers(vcf_path)
 
     logger.info("Validating VCF and input parameters...")
 
@@ -569,7 +572,7 @@ def check_and_validate_args(  # noqa: C901
             subprocess.check_output(
                 "gunzip -c "
                 + vcf_path
-                + " | grep -v '#' | head -n 100000 | awk '{print $5}' | sort | uniq",
+                + " | grep -v '^#' | head -n 100000 | awk '{print $5}' | sort | uniq",
                 shell=True,
             )
             .decode("utf-8")

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import uuid
+import warnings
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -322,18 +323,20 @@ def read_and_filter_genotypes(
     ploidy = infer_ploidy_from_vcf(args.vcf)
 
     # read in data from the source VCF for the current window
-    callset = allel.read_vcf(
-        args.vcf,
-        region=window_region,
-        fields=[
-            "CHROM",
-            "POS",
-            "calldata/GT",
-            "variants/is_snp",
-            "variants/numalt",
-        ],
-        numbers={"GT": ploidy},
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, module="allel")
+        callset = allel.read_vcf(
+            args.vcf,
+            region=window_region,
+            fields=[
+                "CHROM",
+                "POS",
+                "calldata/GT",
+                "variants/is_snp",
+                "variants/numalt",
+            ],
+            numbers={"GT": ploidy},
+        )
 
     # keep track of whether the callset was empty (no sites for this range in the VCF)
     # used by compute_summary_stats to add info about completely missing sites


### PR DESCRIPTION
- Fix #185: change `grep -v '#'` to `grep -v '^#'` in the invariant site check so that VCF data lines containing '#' (e.g. from FASTA headers like
  >assembly#chr#hap) are no longer incorrectly filtered out

- Fix #183: wrap allel.read_vcf() and allel.read_vcf_headers() calls in warnings.catch_warnings() to suppress the spurious "invalid INFO header" UserWarning emitted by scikit-allel during normal operation