### PR TITLE
Ignore fully-masked sites in Tajima's D

### DIFF
--- a/pixy/calc.py
+++ b/pixy/calc.py
@@ -478,9 +478,27 @@ def calc_tajima_d(gt_array: GenotypeArray) -> TajimaDResult:
             a1: float = np.sum(1 / np.arange(1, n))
             watterson_theta += s / a1
 
-    n_mean: float = np.nanmean(allele_counts.sum(axis=1))
+    # Compute n_mean only over sites with at least one observed allele. Masked or fully-missing
+    # sites have an allele-count sum of 0; including them would pull n_mean toward 0 and break
+    # the denominator (b1, c2) when `--sites_file` masks most of the window — producing either
+    # spurious NAs (#186) or wildly inflated values (#188).
+    per_site_n: NDArray[np.int_] = allele_counts.sum(axis=1)
+    observed_per_site_n: NDArray[np.int_] = per_site_n[per_site_n > 0]
+    n_mean: float = float(np.mean(observed_per_site_n)) if observed_per_site_n.size > 0 else 0.0
     # `n` was the per-site count above; re-bind it here to the across-sites rounded mean
     n = int(np.rint(n_mean).astype(int))
+
+    # If no site has even 2 observed alleles, Tajima's D is undefined and the formula below
+    # divides by zero (b1 has `3 * (n - 1)`). Return NA without attempting the calculation.
+    if n < 2:
+        return TajimaDResult(
+            tajima_d="NA",
+            num_sites=int(num_sites),
+            raw_pi=raw_pi,
+            watterson_theta=watterson_theta,
+            d_stdev=float("nan"),
+        )
+
     s_total: int = sum(variant_gt_counts.values())
     a1 = float(np.sum(1 / np.arange(1, n)))
     a2: float = float(np.sum(1 / (np.arange(1, n) ** 2)))

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -971,3 +971,58 @@ def test_calc_tajima_d_tetraploidy() -> None:
     # There is no standalone function or helper for the denominator - this was manually calculated
     # from scikit-allel's code
     assert result.d_stdev == pytest.approx(0.2266425)
+
+
+def test_calc_tajima_d_with_masked_sites_matches_unmasked_subset() -> None:
+    """
+    Tajima's D should ignore fully-missing (masked) sites when computing ``n_mean``.
+
+    Regression for https://github.com/ksamuk/pixy/issues/186 and
+    https://github.com/ksamuk/pixy/issues/188: when ``--sites_file`` masks non-target sites
+    they become rows of ``-1``. Previously their zero allele-count rows pulled ``n_mean`` toward
+    0, which either returned NA or produced wildly negative outliers. The masked array should
+    now yield the same Tajima's D as the equivalent array containing only the unmasked sites.
+    """
+    real_sites = [
+        [[0, 0], [0, 1], [1, 1]],
+        [[0, 1], [0, 1], [1, 1]],
+        [[0, 0], [0, 1], [0, 1]],
+    ]
+    masked_row = [[-1, -1], [-1, -1], [-1, -1]]
+    # 3 real sites surrounded by 6 masked rows (typical `--sites_file` scenario)
+    array_with_masked = GenotypeArray([
+        masked_row,
+        masked_row,
+        *real_sites,
+        masked_row,
+        masked_row,
+        masked_row,
+        masked_row,
+    ])
+    array_unmasked = GenotypeArray(real_sites)
+
+    result_masked = calc_tajima_d(array_with_masked)
+    result_unmasked = calc_tajima_d(array_unmasked)
+
+    assert result_masked.tajima_d == pytest.approx(result_unmasked.tajima_d)
+    assert result_masked.raw_pi == pytest.approx(result_unmasked.raw_pi)
+    assert result_masked.watterson_theta == pytest.approx(result_unmasked.watterson_theta)
+    assert result_masked.d_stdev == pytest.approx(result_unmasked.d_stdev)
+
+
+def test_calc_tajima_d_all_sites_masked_returns_na() -> None:
+    """
+    If every site is masked, Tajima's D is undefined and must return NA without crashing.
+
+    Regression for https://github.com/ksamuk/pixy/issues/186: previously the all-masked window
+    fell through to a divide-by-zero in the ``b1``/``c2`` terms.
+    """
+    array = GenotypeArray([
+        [[-1, -1], [-1, -1], [-1, -1]],
+        [[-1, -1], [-1, -1], [-1, -1]],
+    ])
+
+    result: TajimaDResult = calc_tajima_d(array)
+
+    assert result.tajima_d == "NA"
+    assert result.num_sites == 0


### PR DESCRIPTION
- When computing Tajima's D with a mask, compute the per-site sample size (n_mean) only over sites with observed alleles to avoid zeros from fully-masked rows skewing the mean. 
- Rebind n to the rounded mean and return NA early when n < 2 to prevent divide-by-zero in the Tajima's D denominator. 
- Adds tests to ensure masked sites produce the same result as the unmasked subset and that an all-masked window returns NA (regressions for #186 and possibly #188).