### PR TITLE
Fix Tajima's D aggregation and add optional components

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -80,6 +80,12 @@ Optional
     ``wc_fst_b``, and ``wc_fst_c``. For ``--fst_type hudson``, this
     adds ``hudson_fst_num`` and ``hudson_fst_den``.
 
+**--tajima_components**
+    Include the Tajima's *D* aggregation components in the Tajima's *D*
+    output table. This adds ``tajima_d_s_counts``, a comma-separated list
+    of ``observed_alleles:segregating_sites`` pairs that can be summed
+    across windows to recompute the Tajima's *D* denominator.
+
 **--include_multiallelic_snps**
     Include sites with more than two alleles in the calculation. Disabled by
     default because biallelic-only mode is slightly faster. Added in

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -134,8 +134,10 @@ Stevison & Samuk (2025) for the derivation.
     contributed to the estimate.
 
 ``weighted_no_sites``
-    Sum of the per-site weights across the window. Used as the
-    denominator of ``avg_watterson_theta``.
+    Auxiliary effective-site count that downweights sites by the fraction
+    of observed alleles. This column is provided as a missingness
+    diagnostic and is not used as the denominator of
+    ``avg_watterson_theta``.
 
 Tajima's *D* (tajima_d)
 -----------------------
@@ -162,12 +164,18 @@ data correctly.
     genotype.
 
 ``raw_pi``, ``raw_watterson_theta``
-    The unbiased per-site π and Watterson's θ values used to compute
+    The raw, unscaled π and Watterson's θ component sums used to compute
     *D* (the numerator is ``raw_pi - raw_watterson_theta``).
 
 ``tajima_d_stdev``
     Standard deviation of the *D* statistic over the window (the
     denominator).
+
+``tajima_d_s_counts``
+    Optional column emitted only with ``--tajima_components``. This is a
+    comma-separated list of ``observed_alleles:segregating_sites`` pairs
+    used to recompute ``tajima_d_stdev`` exactly when aggregating windows
+    after running ``pixy``.
 
 Working with pixy output data
 =============================
@@ -180,19 +188,30 @@ Post-hoc aggregating
 
 If you want to combine information across windows after the fact
 (e.g. by averaging), **do not** simply average the per-window summary
-statistics. Instead, sum the raw counts and recompute the ratio. For
-``pi`` and ``dxy``:
+statistics. Instead, sum the raw counts or components and recompute the
+statistic.
+
+Pi (pi)
+^^^^^^^
+
+For π, sum ``count_diffs`` and ``count_comparisons`` across windows, then
+divide:
 
 .. parsed-literal::
 
-    (window 1 count_diffs + window 2 count_diffs) /
-    (window 1 count_comparisons + window 2 count_comparisons)
+    sum(count_diffs) / sum(count_comparisons)
 
-The same principle applies to Watterson's θ — sum the
-``raw_watterson_theta`` and ``weighted_no_sites`` columns across
-windows and divide. For Tajima's *D*, recompute from the raw π and θ
-contributions; do not average ``tajima_d`` values directly across
-windows.
+Dxy (dxy)
+^^^^^^^^^
+
+For d\ :sub:`xy`, use the same ratio as π:
+
+.. parsed-literal::
+
+    sum(count_diffs) / sum(count_comparisons)
+
+FST (fst)
+^^^^^^^^^
 
 For F\ :sub:`ST`, run with ``--fst_components`` and recompute from the
 summed estimator components. For Weir & Cockerham F\ :sub:`ST`:
@@ -206,3 +225,137 @@ For Hudson F\ :sub:`ST`:
 .. parsed-literal::
 
     sum(hudson_fst_num) / sum(hudson_fst_den)
+
+Watterson's θ (watterson_theta)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Watterson's θ can also be aggregated across windows. Sum
+``raw_watterson_theta`` across windows and divide by the sum of
+``no_sites``:
+
+.. parsed-literal::
+
+    sum(raw_watterson_theta) / sum(no_sites)
+
+For Watterson's θ, ``no_var_sites`` and ``weighted_no_sites`` can also be
+summed across windows as descriptive columns, but neither is the
+denominator of ``avg_watterson_theta``.
+
+Tajima's D (tajima_d)
+^^^^^^^^^^^^^^^^^^^^^
+
+Tajima's *D* cannot be exactly aggregated post hoc from the default output
+columns because ``tajima_d_stdev`` is not additive. Do not average
+``tajima_d`` values across windows. To enable exact post-hoc aggregation,
+run with ``--tajima_components`` and sum ``tajima_d_s_counts`` by observed
+allele count across the windows being combined.
+
+Each ``tajima_d_s_counts`` entry is one or more
+``observed_alleles:segregating_sites`` pairs. Here ``observed_alleles`` is
+the number of called alleles at those segregating sites, not the number of
+diploid individuals. For example, if two windows report
+``tajima_d_s_counts`` as ``8:3,10:12`` and ``8:2,12:5``, combine them as
+``8:5,10:12,12:5`` before recomputing the denominator.
+
+This R helper mirrors the denominator calculation used by ``pixy``. Pass
+``aggregate_tajima_d()`` a data frame containing the windows to combine:
+
+.. code:: r
+
+    parse_tajima_d_s_counts <- function(value) {
+      if (length(value) == 0 || is.na(value)) {
+        return(setNames(numeric(), character()))
+      }
+
+      value <- as.character(value)
+      if (value == "" || value == "NA") {
+        return(setNames(numeric(), character()))
+      }
+
+      counts <- setNames(numeric(), character())
+      for (item in strsplit(value, ",", fixed = TRUE)[[1]]) {
+        pair <- strsplit(item, ":", fixed = TRUE)[[1]]
+        n <- pair[1]
+        old <- counts[n]
+        if (is.na(old)) {
+          old <- 0
+        }
+        counts[n] <- old + as.numeric(pair[2])
+      }
+      counts
+    }
+
+    combine_tajima_d_s_counts <- function(values) {
+      total <- setNames(numeric(), character())
+      for (value in values) {
+        counts <- parse_tajima_d_s_counts(value)
+        for (n in names(counts)) {
+          old <- total[n]
+          if (is.na(old)) {
+            old <- 0
+          }
+          total[n] <- old + counts[n]
+        }
+      }
+      total
+    }
+
+    calc_tajima_d_stdev <- function(s_counts) {
+      stdev <- 0
+      for (n_name in names(s_counts)) {
+        n <- as.integer(n_name)
+        s <- as.numeric(s_counts[n_name])
+        if (is.na(n) || n < 2 || s <= 0) {
+          next
+        }
+
+        i <- seq_len(n - 1)
+        a1 <- sum(1 / i)
+        a2 <- sum(1 / (i^2))
+        b1 <- (n + 1) / (3 * (n - 1))
+        b2 <- 2 * (n^2 + n + 3) / (9 * n * (n - 1))
+        c1 <- b1 - (1 / a1)
+        c2 <- b2 - ((n + 2) / (a1 * n)) + (a2 / (a1^2))
+        e1 <- c1 / a1
+        e2 <- c2 / (a1^2 + a2)
+
+        stdev <- stdev + sqrt((e1 * s) + (e2 * s * (s - 1)))
+      }
+      stdev
+    }
+
+    aggregate_tajima_d <- function(rows) {
+      raw_pi <- sum(rows$raw_pi, na.rm = TRUE)
+      raw_watterson_theta <- sum(rows$raw_watterson_theta, na.rm = TRUE)
+      s_counts <- combine_tajima_d_s_counts(rows$tajima_d_s_counts)
+      tajima_d_stdev <- calc_tajima_d_stdev(s_counts)
+      tajima_d <- if (tajima_d_stdev <= 0) {
+        NA_real_
+      } else {
+        (raw_pi - raw_watterson_theta) / tajima_d_stdev
+      }
+
+      data.frame(
+        tajima_d = tajima_d,
+        no_sites = sum(rows$no_sites, na.rm = TRUE),
+        raw_pi = raw_pi,
+        raw_watterson_theta = raw_watterson_theta,
+        tajima_d_stdev = tajima_d_stdev
+      )
+    }
+
+The final calculation is:
+
+.. parsed-literal::
+
+    (sum(raw_pi) - sum(raw_watterson_theta)) / recomputed_tajima_d_stdev
+
+If ``recomputed_tajima_d_stdev`` is zero, the aggregated Tajima's *D* is
+undefined and should be reported as ``NA``. Sum ``no_sites`` across windows
+for the aggregated site count. The important detail is that
+``tajima_d_stdev`` itself is not summable; ``tajima_d_s_counts`` is the
+summable denominator component.
+
+When ``pixy`` internally chunks a large requested window, it uses the same
+segregating-site counts by observed allele count to recompute
+``tajima_d_stdev`` for the requested output window.

--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -225,6 +225,18 @@ def main() -> None:  # noqa: C901
         ),
         required=False,
     )
+    optional.add_argument(
+        "--tajima_components",
+        action="store_true",
+        default=False,
+        help=(
+            "Include Tajima's D aggregation components in the Tajima's D output table. "
+            "This adds tajima_d_s_counts, a comma-separated list of "
+            "observed_alleles:segregating_sites pairs that can be summed across windows. "
+            "Defaults to False."
+        ),
+        required=False,
+    )
     (
         optional.add_argument(
             "--include_multiallelic_snps",
@@ -678,6 +690,7 @@ def main() -> None:  # noqa: C901
                 outpi.drop(
                     [0, 2], axis=1, inplace=True
                 )  # get rid of "pi" and placeholder (NA) columns
+                outpi.drop([11], axis=1, errors="ignore", inplace=True)
                 outsorted = outpi.sort_values([4])  # sort by position
                 # make sure sites, comparisons, missing get written as integers
                 cols = [7, 8, 9, 10]
@@ -738,6 +751,7 @@ def main() -> None:  # noqa: C901
                     drop=True
                 )  # get this statistic, this chrom only
                 outdxy.drop([0], axis=1, inplace=True)  # get rid of "dxy"
+                outdxy.drop([11], axis=1, errors="ignore", inplace=True)
                 outsorted = outdxy.sort_values([4])  # sort by position
                 # make sure sites, comparisons, missing get written as integers
                 cols = [7, 8, 9, 10]
@@ -828,6 +842,7 @@ def main() -> None:  # noqa: C901
 
                 if chromosome_has_data:
                     outfst.drop([0], axis=1, inplace=True)  # get rid of "fst"
+                    outfst.drop([11], axis=1, errors="ignore", inplace=True)
                     outsorted = outfst.sort_values([4])  # sort by position
                     # make sure sites (but not components like pi/dxy)
                     cols = [7]
@@ -907,6 +922,7 @@ def main() -> None:  # noqa: C901
                 outwatterson_theta.drop(
                     [0, 2], axis=1, inplace=True
                 )  # get rid of "watterson_theta" and placeholder (NA) columns
+                outwatterson_theta.drop([11], axis=1, errors="ignore", inplace=True)
                 outsorted = outwatterson_theta.sort_values([4])  # sort by position
                 # make sure sites, comparisons, missing get written as floats
                 cols = [7, 8, 9, 10]
@@ -924,26 +940,20 @@ def main() -> None:  # noqa: C901
             os.remove(tajima_d_file)
 
         outfile = open(tajima_d_file, "a")
-        outfile.write(
-            "pop"
-            + "\t"
-            + "chromosome"
-            + "\t"
-            + "window_pos_1"
-            + "\t"
-            + "window_pos_2"
-            + "\t"
-            + "tajima_d"
-            + "\t"
-            + "no_sites"
-            + "\t"
-            + "raw_pi"
-            + "\t"
-            + "raw_watterson_theta"
-            + "\t"
-            + "tajima_d_stdev"
-            + "\n"
-        )
+        tajima_header_columns = [
+            "pop",
+            "chromosome",
+            "window_pos_1",
+            "window_pos_2",
+            "tajima_d",
+            "no_sites",
+            "raw_pi",
+            "raw_watterson_theta",
+            "tajima_d_stdev",
+        ]
+        if pixy_args.tajima_components:
+            tajima_header_columns.append("tajima_d_s_counts")
+        outfile.write("\t".join(tajima_header_columns) + "\n")
 
         if aggregate:  # put winsizes back together for each population to make final_window_size
             for chromosome in chrom_list:
@@ -956,6 +966,8 @@ def main() -> None:  # noqa: C901
                 outsorted = pixy.core.aggregate_output(
                     outtajima_d, PixyStat.TAJIMA_D.value, chromosome, window_size, args.fst_type
                 )
+                if not pixy_args.tajima_components:
+                    outsorted = outsorted.iloc[:, :-1]
                 outsorted.to_csv(
                     outfile, sep="\t", mode="a", header=False, index=False, na_rep="NA"
                 )  # write
@@ -968,10 +980,11 @@ def main() -> None:  # noqa: C901
                 outtajima_d.drop(
                     [0, 2], axis=1, inplace=True
                 )  # get rid of "theta" and placeholder (NA) columns
+                if not pixy_args.tajima_components:
+                    outtajima_d.drop([11], axis=1, errors="ignore", inplace=True)
                 outsorted = outtajima_d.sort_values([4])  # sort by position
-                # make sure sites, comparisons, missing get written as floats
-                cols = [7, 8, 9, 10]
-                outsorted[cols] = outsorted[cols].astype("float64")
+                outsorted[7] = outsorted[7].astype("Int64")
+                outsorted[[8, 9, 10]] = outsorted[[8, 9, 10]].astype("float64")
                 outsorted.to_csv(
                     outfile, sep="\t", mode="a", header=False, index=False, na_rep="NA"
                 )  # write

--- a/pixy/args_validation.py
+++ b/pixy/args_validation.py
@@ -65,6 +65,8 @@ class PixyArgs:
         fst_type: the FST estimator to use, one of either 'WC' (Weir and Cockerham 1984) or
             'HUDSON' (Hudson 1992, Bhatia et al. 2013). Defaults to 'WC'.
         fst_components: whether to include FST estimator components in the final FST output table
+        tajima_components: whether to include Tajima's D aggregation components in the final
+            Tajima's D output table
         temp_file: a Path to which to write intermediate `pixy` results, assigned based on the value
             of `output_dir`
         ploidy_map: a mapping from contig name to inferred ploidy. Built from the first record of
@@ -88,6 +90,7 @@ class PixyArgs:
     num_cores: int = 1
     fst_type: FSTEstimator = FSTEstimator.WC
     fst_components: bool = False
+    tajima_components: bool = False
     output_prefix: str = "pixy"
     chunk_size: int = 100000
     bed_df: Union[pandas.DataFrame, None] = None
@@ -777,6 +780,7 @@ def check_and_validate_args(  # noqa: C901
         chunk_size=args.chunk_size,
         fst_type=FSTEstimator[args.fst_type.upper()],
         fst_components=getattr(args, "fst_components", False),
+        tajima_components=getattr(args, "tajima_components", False),
         temp_file=tmp_path,
         ploidy_map=ploidy_map,
     )

--- a/pixy/calc.py
+++ b/pixy/calc.py
@@ -3,6 +3,7 @@ from itertools import combinations
 from typing import Any
 from typing import Counter as CounterType
 from typing import List
+from typing import Mapping
 from typing import Tuple
 from typing import Union
 
@@ -28,6 +29,7 @@ from pixy.models import WattersonThetaResult
 # adding 2 `TypeAlias`s for additional type safety and defensiveness
 VariantCount: TypeAlias = int
 SiteCount: TypeAlias = int
+ObservedAlleleCount: TypeAlias = int
 
 
 def count_diff_comp_missing(row: NDArray[Any], n_haps: int) -> Tuple[int, int, int]:
@@ -414,8 +416,8 @@ def calc_watterson_theta(gt_array: GenotypeArray) -> WattersonThetaResult:
             reciprocal_sum: float = np.sum(1 / np.arange(1, num_genotypes))
             watterson_theta += site_count / reciprocal_sum
 
-    # calculate number of sites excluding missing sites (those with no genotypes)
-    # this allows calculation of an averaged Watterson's in the context of missing sites
+    # Calculate an auxiliary effective-site count that reflects within-site missingness.
+    # The Watterson's theta denominator is `num_sites`; this value is emitted as a diagnostic.
 
     weighted_sites: float
     if max(all_sites_counter) == 0:
@@ -444,6 +446,57 @@ def calc_watterson_theta(gt_array: GenotypeArray) -> WattersonThetaResult:
         raw_theta=watterson_theta,
         num_weighted_sites=weighted_sites,
     )
+
+
+def calc_tajima_d_stdev(
+    variant_gt_counts: Mapping[ObservedAlleleCount, SiteCount],
+) -> float:
+    """
+    Calculates the standard deviation term used as Tajima's D denominator.
+
+    The missing-data correction from Bailey et al. 2025 sums the denominator over variant-site
+    classes with the same number of observed alleles. `variant_gt_counts` maps each observed allele
+    count `n` to the number of segregating sites observed with that count.
+    """
+    d_stdev = 0.0
+    for n, s in variant_gt_counts.items():
+        if n < 2 or s <= 0:
+            continue
+
+        a1 = float(np.sum(1 / np.arange(1, n)))
+        a2 = float(np.sum(1 / (np.arange(1, n) ** 2)))
+        b1 = (n + 1) / (3 * (n - 1))
+        b2 = 2 * (n**2 + n + 3) / (9 * n * (n - 1))
+        c1 = b1 - (1 / a1)
+        c2 = b2 - ((n + 2) / (a1 * n)) + (a2 / (a1**2))
+        e1 = c1 / a1
+        e2 = c2 / (a1**2 + a2)
+        d_stdev += np.sqrt((e1 * s) + (e2 * s * (s - 1)))
+
+    return float(d_stdev)
+
+
+def serialize_tajima_d_variant_counts(
+    variant_gt_counts: Mapping[ObservedAlleleCount, SiteCount],
+) -> str:
+    """Serializes Tajima's D observed-allele-count classes for the temp file."""
+    if not variant_gt_counts:
+        return "NA"
+
+    return ",".join(f"{n}:{s}" for n, s in sorted(variant_gt_counts.items()))
+
+
+def deserialize_tajima_d_variant_counts(value: object) -> CounterType[ObservedAlleleCount]:
+    """Deserializes Tajima's D observed-allele-count classes from the temp file."""
+    if not isinstance(value, str) or value == "NA" or value == "":
+        return Counter()
+
+    counts: CounterType[ObservedAlleleCount] = Counter()
+    for item in value.split(","):
+        n, s = item.split(":")
+        counts[int(n)] += int(s)
+
+    return counts
 
 
 def calc_tajima_d(gt_array: GenotypeArray) -> TajimaDResult:
@@ -492,37 +545,7 @@ def calc_tajima_d(gt_array: GenotypeArray) -> TajimaDResult:
             a1: float = np.sum(1 / np.arange(1, n))
             watterson_theta += s / a1
 
-    # Compute n_mean only over sites with at least one observed allele. Masked or fully-missing
-    # sites have an allele-count sum of 0; including them would pull n_mean toward 0 and break
-    # the denominator (b1, c2) when `--sites_file` masks most of the window — producing either
-    # spurious NAs (#186) or wildly inflated values (#188).
-    per_site_n: NDArray[np.int_] = allele_counts.sum(axis=1)
-    observed_per_site_n: NDArray[np.int_] = per_site_n[per_site_n > 0]
-    n_mean: float = float(np.mean(observed_per_site_n)) if observed_per_site_n.size > 0 else 0.0
-    # `n` was the per-site count above; re-bind it here to the across-sites rounded mean
-    n = int(np.rint(n_mean).astype(int))
-
-    # If no site has even 2 observed alleles, Tajima's D is undefined and the formula below
-    # divides by zero (b1 has `3 * (n - 1)`). Return NA without attempting the calculation.
-    if n < 2:
-        return TajimaDResult(
-            tajima_d="NA",
-            num_sites=int(num_sites),
-            raw_pi=raw_pi,
-            watterson_theta=watterson_theta,
-            d_stdev=float("nan"),
-        )
-
-    s_total: int = sum(variant_gt_counts.values())
-    a1 = float(np.sum(1 / np.arange(1, n)))
-    a2: float = float(np.sum(1 / (np.arange(1, n) ** 2)))
-    b1: float = (n + 1) / (3 * (n - 1))
-    b2: float = 2 * (n**2 + n + 3) / (9 * n * (n - 1))
-    c1: float = b1 - (1 / a1)
-    c2: float = b2 - ((n + 2) / (a1 * n)) + (a2 / (a1**2))
-    e1: float = c1 / a1
-    e2: float = c2 / (a1**2 + a2)
-    d_stdev: float = np.sqrt((e1 * s_total) + (e2 * s_total * (s_total - 1)))
+    d_stdev = calc_tajima_d_stdev(variant_gt_counts)
 
     tajima_d: Union[float, NA]
     if d_stdev > 0 and not any(np.isnan(x) for x in [raw_pi, watterson_theta, d_stdev]):
@@ -541,4 +564,5 @@ def calc_tajima_d(gt_array: GenotypeArray) -> TajimaDResult:
         raw_pi=raw_pi,
         watterson_theta=watterson_theta,
         d_stdev=d_stdev,
+        variant_gt_counts=dict(variant_gt_counts),
     )

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -48,11 +48,11 @@ from pixy.stats.summary import compute_summary_fst
 from pixy.stats.summary import compute_summary_pi
 from pixy.stats.summary import precompute_filtered_variant_array
 
-agg_label_column = 12
-agg_window_pos_1_column = 13
-agg_window_pos_2_column = 14
-agg_chromosome_column = 15
-agg_stat_column = 16
+agg_label_column = -1
+agg_window_pos_1_column = -2
+agg_window_pos_2_column = -3
+agg_chromosome_column = -4
+agg_stat_column = -5
 
 
 def _coerce_aggregated_output_types(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
@@ -187,7 +187,7 @@ def aggregate_output(
     Returns:
         outsorted: a pandas.DataFrame that stores aggregated statistics for each window
     """
-    outsorted = df_for_stat.sort_values([4])  # sort by position
+    outsorted = df_for_stat.sort_values([4]).copy()  # sort by position
     interval_start = df_for_stat[4].min()
     interval_end = df_for_stat[4].max()
     # create a subset of the window list specific to this chunk
@@ -201,9 +201,8 @@ def aggregate_output(
     outsorted[agg_window_pos_2_column] = edges[assignments + 1]
 
     outsorted = _group_aggregated_output(outsorted, stat)
-    outsorted[[agg_window_pos_1_column, agg_window_pos_2_column]] = outsorted[
-        [agg_window_pos_1_column, agg_window_pos_2_column]
-    ].astype("int64")
+    outsorted[agg_window_pos_1_column] = outsorted[agg_window_pos_1_column].astype("int64")
+    outsorted[agg_window_pos_2_column] = outsorted[agg_window_pos_2_column].astype("int64")
     outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
     outsorted[agg_stat_column] = outsorted[agg_stat_column].fillna("NA")

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -133,23 +133,23 @@ def _calculate_aggregated_stat(
 ) -> pandas.DataFrame:
     """Calculates the final statistic from aggregated temp-row components."""
     if stat == "pi" or stat == "dxy":
-        outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
+        outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[9]
     elif stat == "watterson_theta":
-        outsorted[agg_stat_column] = outsorted[8] / outsorted[7]
+        outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[7]
     elif stat == "tajima_d":
         d_stdev = outsorted[10]
-        outsorted[agg_stat_column] = np.where(
+        outsorted.loc[:, agg_stat_column] = np.where(
             d_stdev.gt(0) & d_stdev.notna(),
             (outsorted[8] - outsorted[9]) / d_stdev,
             np.nan,
         )
     elif stat == "fst":
         if fst_type == "wc":
-            outsorted[agg_stat_column] = outsorted[8] / (
+            outsorted.loc[:, agg_stat_column] = outsorted[8] / (
                 outsorted[8] + outsorted[9] + outsorted[10]
             )
         elif fst_type == "hudson":
-            outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
+            outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[9]
 
     return outsorted
 
@@ -196,21 +196,26 @@ def aggregate_output(
     assignments, edges = pandas.cut(
         outsorted[4], bins=bins, labels=False, retbins=True, include_lowest=True
     )
-    outsorted[agg_label_column] = assignments
-    outsorted[agg_window_pos_1_column] = edges[assignments] + 1
-    outsorted[agg_window_pos_2_column] = edges[assignments + 1]
+    outsorted.loc[:, agg_label_column] = assignments
+    outsorted.loc[:, agg_window_pos_1_column] = edges[assignments] + 1
+    outsorted.loc[:, agg_window_pos_2_column] = edges[assignments + 1]
 
     outsorted = _group_aggregated_output(outsorted, stat)
-    outsorted[agg_window_pos_1_column] = outsorted[agg_window_pos_1_column].astype("int64")
-    outsorted[agg_window_pos_2_column] = outsorted[agg_window_pos_2_column].astype("int64")
+    outsorted.loc[:, agg_window_pos_1_column] = outsorted.loc[:, agg_window_pos_1_column].astype(
+        "int64"
+    )
+    outsorted.loc[:, agg_window_pos_2_column] = outsorted.loc[:, agg_window_pos_2_column].astype(
+        "int64"
+    )
     outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
-    outsorted[agg_stat_column] = outsorted[agg_stat_column].fillna("NA")
-    outsorted[agg_chromosome_column] = chromosome
+    outsorted.loc[:, agg_stat_column] = outsorted.loc[:, agg_stat_column].fillna("NA")
+    outsorted.loc[:, agg_chromosome_column] = chromosome
 
     # reorder columns
     if stat == "tajima_d":
-        outsorted = outsorted[
+        outsorted = outsorted.loc[
+            :,
             [
                 1,
                 agg_chromosome_column,
@@ -222,10 +227,11 @@ def aggregate_output(
                 9,
                 10,
                 11,
-            ]
+            ],
         ]
     elif stat == "pi" or stat == "watterson_theta":
-        outsorted = outsorted[
+        outsorted = outsorted.loc[
+            :,
             [
                 1,
                 agg_chromosome_column,
@@ -236,10 +242,11 @@ def aggregate_output(
                 8,
                 9,
                 10,
-            ]
+            ],
         ]
     else:  # dxy and fst have 2 population fields
-        outsorted = outsorted[
+        outsorted = outsorted.loc[
+            :,
             [
                 1,
                 2,
@@ -251,7 +258,7 @@ def aggregate_output(
                 8,
                 9,
                 10,
-            ]
+            ],
         ]
 
     return _coerce_aggregated_output_types(outsorted, stat)

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -57,10 +57,6 @@ agg_stat_column = 16
 
 def _coerce_aggregated_output_types(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
     """Coerce aggregate output columns to the dtypes expected in final output."""
-    outsorted[[agg_window_pos_1_column, agg_window_pos_2_column]] = outsorted[
-        [agg_window_pos_1_column, agg_window_pos_2_column]
-    ].astype("int64")
-
     if stat == "pi" or stat == "dxy":
         outsorted[[7, 8, 9, 10]] = outsorted[[7, 8, 9, 10]].astype("int32")
     elif stat == "watterson_theta":
@@ -205,6 +201,9 @@ def aggregate_output(
     outsorted[agg_window_pos_2_column] = edges[assignments + 1]
 
     outsorted = _group_aggregated_output(outsorted, stat)
+    outsorted[[agg_window_pos_1_column, agg_window_pos_2_column]] = outsorted[
+        [agg_window_pos_1_column, agg_window_pos_2_column]
+    ].astype("int64")
     outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
     outsorted[agg_stat_column] = outsorted[agg_stat_column].fillna("NA")

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -48,11 +48,11 @@ from pixy.stats.summary import compute_summary_fst
 from pixy.stats.summary import compute_summary_pi
 from pixy.stats.summary import precompute_filtered_variant_array
 
-agg_label_column = -1
-agg_window_pos_1_column = -2
-agg_window_pos_2_column = -3
-agg_chromosome_column = -4
-agg_stat_column = -5
+agg_label_column = 12
+agg_window_pos_1_column = 13
+agg_window_pos_2_column = 14
+agg_chromosome_column = 15
+agg_stat_column = 16
 
 
 def _coerce_aggregated_output_types(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
@@ -89,11 +89,10 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
         return (
             outsorted.groupby(
                 [1, agg_window_pos_1_column, agg_window_pos_2_column],
-                as_index=False,
                 dropna=False,
             )
             .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
-            .reset_index(drop=True)
+            .reset_index()
         )
 
     if stat == "tajima_d":
@@ -103,11 +102,10 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
         grouped = (
             outsorted.groupby(
                 [1, agg_window_pos_1_column, agg_window_pos_2_column],
-                as_index=False,
                 dropna=False,
             )
             .agg({7: "sum", 8: "sum", 9: "sum", 11: _aggregate_tajima_d_variant_counts})
-            .reset_index(drop=True)
+            .reset_index()
         )
         grouped[10] = grouped[11].apply(
             lambda value: calc_tajima_d_stdev(deserialize_tajima_d_variant_counts(value))
@@ -118,11 +116,10 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
         return (
             outsorted.groupby(
                 [1, 2, agg_window_pos_1_column, agg_window_pos_2_column],
-                as_index=False,
                 dropna=False,
             )
             .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
-            .reset_index(drop=True)
+            .reset_index()
         )
 
     raise ValueError(f"Unsupported statistic for aggregation: {stat}")
@@ -133,23 +130,23 @@ def _calculate_aggregated_stat(
 ) -> pandas.DataFrame:
     """Calculates the final statistic from aggregated temp-row components."""
     if stat == "pi" or stat == "dxy":
-        outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[9]
+        outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
     elif stat == "watterson_theta":
-        outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[7]
+        outsorted[agg_stat_column] = outsorted[8] / outsorted[7]
     elif stat == "tajima_d":
         d_stdev = outsorted[10]
-        outsorted.loc[:, agg_stat_column] = np.where(
+        outsorted[agg_stat_column] = np.where(
             d_stdev.gt(0) & d_stdev.notna(),
             (outsorted[8] - outsorted[9]) / d_stdev,
             np.nan,
         )
     elif stat == "fst":
         if fst_type == "wc":
-            outsorted.loc[:, agg_stat_column] = outsorted[8] / (
+            outsorted[agg_stat_column] = outsorted[8] / (
                 outsorted[8] + outsorted[9] + outsorted[10]
             )
         elif fst_type == "hudson":
-            outsorted.loc[:, agg_stat_column] = outsorted[8] / outsorted[9]
+            outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
 
     return outsorted
 
@@ -196,26 +193,22 @@ def aggregate_output(
     assignments, edges = pandas.cut(
         outsorted[4], bins=bins, labels=False, retbins=True, include_lowest=True
     )
-    outsorted.loc[:, agg_label_column] = assignments
-    outsorted.loc[:, agg_window_pos_1_column] = edges[assignments] + 1
-    outsorted.loc[:, agg_window_pos_2_column] = edges[assignments + 1]
+    outsorted[agg_label_column] = assignments
+    outsorted[agg_window_pos_1_column] = edges[assignments] + 1
+    outsorted[agg_window_pos_2_column] = edges[assignments + 1]
 
     outsorted = _group_aggregated_output(outsorted, stat)
-    outsorted.loc[:, agg_window_pos_1_column] = outsorted.loc[:, agg_window_pos_1_column].astype(
-        "int64"
-    )
-    outsorted.loc[:, agg_window_pos_2_column] = outsorted.loc[:, agg_window_pos_2_column].astype(
-        "int64"
-    )
+    outsorted[[agg_window_pos_1_column, agg_window_pos_2_column]] = outsorted[
+        [agg_window_pos_1_column, agg_window_pos_2_column]
+    ].astype("int64")
     outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
-    outsorted.loc[:, agg_stat_column] = outsorted.loc[:, agg_stat_column].fillna("NA")
-    outsorted.loc[:, agg_chromosome_column] = chromosome
+    outsorted[agg_stat_column] = outsorted[agg_stat_column].fillna("NA")
+    outsorted[agg_chromosome_column] = chromosome
 
     # reorder columns
     if stat == "tajima_d":
-        outsorted = outsorted.loc[
-            :,
+        outsorted = outsorted[
             [
                 1,
                 agg_chromosome_column,
@@ -227,11 +220,10 @@ def aggregate_output(
                 9,
                 10,
                 11,
-            ],
+            ]
         ]
     elif stat == "pi" or stat == "watterson_theta":
-        outsorted = outsorted.loc[
-            :,
+        outsorted = outsorted[
             [
                 1,
                 agg_chromosome_column,
@@ -242,11 +234,10 @@ def aggregate_output(
                 8,
                 9,
                 10,
-            ],
+            ]
         ]
     else:  # dxy and fst have 2 population fields
-        outsorted = outsorted.loc[
-            :,
+        outsorted = outsorted[
             [
                 1,
                 2,
@@ -258,7 +249,7 @@ def aggregate_output(
                 8,
                 9,
                 10,
-            ],
+            ]
         ]
 
     return _coerce_aggregated_output_types(outsorted, stat)

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -34,7 +34,10 @@ from pixy.args_validation import validate_sites_path
 from pixy.args_validation import validate_vcf_path
 from pixy.args_validation import validate_window_and_interval_args
 from pixy.calc import calc_tajima_d
+from pixy.calc import calc_tajima_d_stdev
 from pixy.calc import calc_watterson_theta
+from pixy.calc import deserialize_tajima_d_variant_counts
+from pixy.calc import serialize_tajima_d_variant_counts
 from pixy.enums import FSTEstimator
 from pixy.enums import PixyStat
 from pixy.models import PixyTempResult
@@ -44,6 +47,111 @@ from pixy.stats.summary import compute_summary_dxy
 from pixy.stats.summary import compute_summary_fst
 from pixy.stats.summary import compute_summary_pi
 from pixy.stats.summary import precompute_filtered_variant_array
+
+AGG_LABEL_COLUMN = 12
+AGG_WINDOW_POS_1_COLUMN = 13
+AGG_WINDOW_POS_2_COLUMN = 14
+AGG_CHROMOSOME_COLUMN = 15
+AGG_STAT_COLUMN = 16
+
+
+def _coerce_aggregated_output_types(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
+    """Coerce aggregate output columns to the dtypes expected in final output."""
+    if stat == "pi" or stat == "dxy":
+        outsorted[[7, 8, 9, 10]] = outsorted[[7, 8, 9, 10]].astype("int32")
+    elif stat == "watterson_theta":
+        outsorted[7] = outsorted[7].astype("int32")
+        outsorted[8] = outsorted[8].astype("float64")
+        outsorted[9] = outsorted[9].astype("int32")
+        outsorted[10] = outsorted[10].astype("float64")
+    elif stat == "tajima_d":
+        outsorted[7] = outsorted[7].astype("int32")
+        outsorted[[8, 9, 10]] = outsorted[[8, 9, 10]].astype("float64")
+    elif stat == "fst":
+        outsorted[7] = outsorted[7].astype("int32")
+
+    return outsorted
+
+
+def _aggregate_tajima_d_variant_counts(count_strings: pandas.Series) -> str:
+    """Aggregates serialized Tajima's D observed-allele-count classes from temp rows."""
+    variant_gt_counts: Dict[int, int] = {}
+    for count_string in count_strings:
+        for n, s in deserialize_tajima_d_variant_counts(count_string).items():
+            variant_gt_counts[n] = variant_gt_counts.get(n, 0) + s
+
+    return serialize_tajima_d_variant_counts(variant_gt_counts)
+
+
+def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
+    """Groups temp rows by the final output-window coordinates."""
+    if stat in {"pi", "watterson_theta"}:
+        return (
+            outsorted.groupby(
+                [1, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                as_index=False,
+                dropna=False,
+            )
+            .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
+            .reset_index(drop=True)
+        )
+
+    if stat == "tajima_d":
+        if 11 not in outsorted.columns:
+            raise ValueError("Tajima's D aggregation requires observed-allele-count classes.")
+
+        grouped = (
+            outsorted.groupby(
+                [1, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                as_index=False,
+                dropna=False,
+            )
+            .agg({7: "sum", 8: "sum", 9: "sum", 11: _aggregate_tajima_d_variant_counts})
+            .reset_index(drop=True)
+        )
+        grouped[10] = grouped[11].apply(
+            lambda value: calc_tajima_d_stdev(deserialize_tajima_d_variant_counts(value))
+        )
+        return grouped
+
+    if stat == "dxy" or stat == "fst":
+        return (
+            outsorted.groupby(
+                [1, 2, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                as_index=False,
+                dropna=False,
+            )
+            .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
+            .reset_index(drop=True)
+        )
+
+    raise ValueError(f"Unsupported statistic for aggregation: {stat}")
+
+
+def _calculate_aggregated_stat(
+    outsorted: pandas.DataFrame, stat: str, fst_type: str
+) -> pandas.DataFrame:
+    """Calculates the final statistic from aggregated temp-row components."""
+    if stat == "pi" or stat == "dxy":
+        outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[9]
+    elif stat == "watterson_theta":
+        outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[7]
+    elif stat == "tajima_d":
+        d_stdev = outsorted[10]
+        outsorted[AGG_STAT_COLUMN] = np.where(
+            d_stdev.gt(0) & d_stdev.notna(),
+            (outsorted[8] - outsorted[9]) / d_stdev,
+            np.nan,
+        )
+    elif stat == "fst":
+        if fst_type == "wc":
+            outsorted[AGG_STAT_COLUMN] = outsorted[8] / (
+                outsorted[8] + outsorted[9] + outsorted[10]
+            )
+        elif fst_type == "hudson":
+            outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[9]
+
+    return outsorted
 
 
 def aggregate_output(
@@ -88,54 +196,63 @@ def aggregate_output(
     assignments, edges = pandas.cut(
         outsorted[4], bins=bins, labels=False, retbins=True, include_lowest=True
     )
-    outsorted["label"] = assignments
-    outsorted["window_pos_1"] = edges[assignments] + 1
-    outsorted["window_pos_2"] = edges[assignments + 1]
+    outsorted[AGG_LABEL_COLUMN] = assignments
+    outsorted[AGG_WINDOW_POS_1_COLUMN] = edges[assignments] + 1
+    outsorted[AGG_WINDOW_POS_2_COLUMN] = edges[assignments + 1]
 
-    # group by population, window
-    if stat == "pi" or stat == "tajima_d":  # pi and tajima_d only have one population field
-        outsorted = (
-            outsorted.groupby([1, "window_pos_1", "window_pos_2"], as_index=False, dropna=False)
-            .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
-            .reset_index()
-        )
-    elif stat == "dxy" or stat == "fst":  # dxy and fst have 2 population fields
-        outsorted = (
-            outsorted.groupby([1, 2, "window_pos_1", "window_pos_2"], as_index=False, dropna=False)
-            .agg({7: "sum", 8: "sum", 9: "sum", 10: "sum"})
-            .reset_index()
-        )
+    outsorted = _group_aggregated_output(outsorted, stat)
+    outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
-    if stat == "pi" or stat == "dxy" or stat == "watterson_theta" or stat == "tajima_d":
-        outsorted[stat] = outsorted[8] / outsorted[9]
-    elif stat == "fst":
-        if fst_type == "wc":
-            outsorted[stat] = outsorted[8] / (outsorted[8] + outsorted[9] + outsorted[10])
-        elif fst_type == "hudson":
-            # 'a' is the numerator of hudson and 'b' is the denominator
-            # (there is no 'c')
-            outsorted[stat] = outsorted[8] / (outsorted[9])
-
-    outsorted[stat].fillna("NA", inplace=True)
-    outsorted["chromosome"] = chromosome
+    outsorted[AGG_STAT_COLUMN].fillna("NA", inplace=True)
+    outsorted[AGG_CHROMOSOME_COLUMN] = chromosome
 
     # reorder columns
-    if (
-        stat == "pi" or stat == "watterson_theta" or stat == "tajima_d"
-    ):  # pi, Watterson's theta and Tajima's D only have one population field
-        outsorted = outsorted[[1, "chromosome", "window_pos_1", "window_pos_2", stat, 7, 8, 9, 10]]
+    if stat == "tajima_d":
+        outsorted = outsorted[
+            [
+                1,
+                AGG_CHROMOSOME_COLUMN,
+                AGG_WINDOW_POS_1_COLUMN,
+                AGG_WINDOW_POS_2_COLUMN,
+                AGG_STAT_COLUMN,
+                7,
+                8,
+                9,
+                10,
+                11,
+            ]
+        ]
+    elif stat == "pi" or stat == "watterson_theta":
+        outsorted = outsorted[
+            [
+                1,
+                AGG_CHROMOSOME_COLUMN,
+                AGG_WINDOW_POS_1_COLUMN,
+                AGG_WINDOW_POS_2_COLUMN,
+                AGG_STAT_COLUMN,
+                7,
+                8,
+                9,
+                10,
+            ]
+        ]
     else:  # dxy and fst have 2 population fields
         outsorted = outsorted[
-            [1, 2, "chromosome", "window_pos_1", "window_pos_2", stat, 7, 8, 9, 10]
+            [
+                1,
+                2,
+                AGG_CHROMOSOME_COLUMN,
+                AGG_WINDOW_POS_1_COLUMN,
+                AGG_WINDOW_POS_2_COLUMN,
+                AGG_STAT_COLUMN,
+                7,
+                8,
+                9,
+                10,
+            ]
         ]
 
-    # make sure sites, comparisons, missing get written as floats
-    if stat == "pi" or stat == "dxy" or stat == "watterson_theta" or stat == "tajima_d":
-        cols = [7, 8, 9, 10]
-    elif stat == "fst":
-        cols = [7]
-    outsorted[cols] = outsorted[cols].astype("int32")
-    return outsorted
+    return _coerce_aggregated_output_types(outsorted, stat)
 
 
 # function for breaking down large windows into chunks
@@ -633,6 +750,9 @@ def compute_summary_stats(  # noqa: C901
                     total_differences=tajima_result.raw_pi,
                     total_comparisons=tajima_result.watterson_theta,
                     total_missing=tajima_result.d_stdev,
+                    tajima_d_variant_counts=serialize_tajima_d_variant_counts(
+                        tajima_result.variant_gt_counts
+                    ),
                 )
                 pixy_output.append(pixy_results)
 

--- a/pixy/core.py
+++ b/pixy/core.py
@@ -48,15 +48,19 @@ from pixy.stats.summary import compute_summary_fst
 from pixy.stats.summary import compute_summary_pi
 from pixy.stats.summary import precompute_filtered_variant_array
 
-AGG_LABEL_COLUMN = 12
-AGG_WINDOW_POS_1_COLUMN = 13
-AGG_WINDOW_POS_2_COLUMN = 14
-AGG_CHROMOSOME_COLUMN = 15
-AGG_STAT_COLUMN = 16
+agg_label_column = 12
+agg_window_pos_1_column = 13
+agg_window_pos_2_column = 14
+agg_chromosome_column = 15
+agg_stat_column = 16
 
 
 def _coerce_aggregated_output_types(outsorted: pandas.DataFrame, stat: str) -> pandas.DataFrame:
     """Coerce aggregate output columns to the dtypes expected in final output."""
+    outsorted[[agg_window_pos_1_column, agg_window_pos_2_column]] = outsorted[
+        [agg_window_pos_1_column, agg_window_pos_2_column]
+    ].astype("int64")
+
     if stat == "pi" or stat == "dxy":
         outsorted[[7, 8, 9, 10]] = outsorted[[7, 8, 9, 10]].astype("int32")
     elif stat == "watterson_theta":
@@ -88,7 +92,7 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
     if stat in {"pi", "watterson_theta"}:
         return (
             outsorted.groupby(
-                [1, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                [1, agg_window_pos_1_column, agg_window_pos_2_column],
                 as_index=False,
                 dropna=False,
             )
@@ -102,7 +106,7 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
 
         grouped = (
             outsorted.groupby(
-                [1, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                [1, agg_window_pos_1_column, agg_window_pos_2_column],
                 as_index=False,
                 dropna=False,
             )
@@ -117,7 +121,7 @@ def _group_aggregated_output(outsorted: pandas.DataFrame, stat: str) -> pandas.D
     if stat == "dxy" or stat == "fst":
         return (
             outsorted.groupby(
-                [1, 2, AGG_WINDOW_POS_1_COLUMN, AGG_WINDOW_POS_2_COLUMN],
+                [1, 2, agg_window_pos_1_column, agg_window_pos_2_column],
                 as_index=False,
                 dropna=False,
             )
@@ -133,23 +137,23 @@ def _calculate_aggregated_stat(
 ) -> pandas.DataFrame:
     """Calculates the final statistic from aggregated temp-row components."""
     if stat == "pi" or stat == "dxy":
-        outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[9]
+        outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
     elif stat == "watterson_theta":
-        outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[7]
+        outsorted[agg_stat_column] = outsorted[8] / outsorted[7]
     elif stat == "tajima_d":
         d_stdev = outsorted[10]
-        outsorted[AGG_STAT_COLUMN] = np.where(
+        outsorted[agg_stat_column] = np.where(
             d_stdev.gt(0) & d_stdev.notna(),
             (outsorted[8] - outsorted[9]) / d_stdev,
             np.nan,
         )
     elif stat == "fst":
         if fst_type == "wc":
-            outsorted[AGG_STAT_COLUMN] = outsorted[8] / (
+            outsorted[agg_stat_column] = outsorted[8] / (
                 outsorted[8] + outsorted[9] + outsorted[10]
             )
         elif fst_type == "hudson":
-            outsorted[AGG_STAT_COLUMN] = outsorted[8] / outsorted[9]
+            outsorted[agg_stat_column] = outsorted[8] / outsorted[9]
 
     return outsorted
 
@@ -196,25 +200,25 @@ def aggregate_output(
     assignments, edges = pandas.cut(
         outsorted[4], bins=bins, labels=False, retbins=True, include_lowest=True
     )
-    outsorted[AGG_LABEL_COLUMN] = assignments
-    outsorted[AGG_WINDOW_POS_1_COLUMN] = edges[assignments] + 1
-    outsorted[AGG_WINDOW_POS_2_COLUMN] = edges[assignments + 1]
+    outsorted[agg_label_column] = assignments
+    outsorted[agg_window_pos_1_column] = edges[assignments] + 1
+    outsorted[agg_window_pos_2_column] = edges[assignments + 1]
 
     outsorted = _group_aggregated_output(outsorted, stat)
     outsorted = _calculate_aggregated_stat(outsorted, stat, fst_type)
 
-    outsorted[AGG_STAT_COLUMN].fillna("NA", inplace=True)
-    outsorted[AGG_CHROMOSOME_COLUMN] = chromosome
+    outsorted[agg_stat_column] = outsorted[agg_stat_column].fillna("NA")
+    outsorted[agg_chromosome_column] = chromosome
 
     # reorder columns
     if stat == "tajima_d":
         outsorted = outsorted[
             [
                 1,
-                AGG_CHROMOSOME_COLUMN,
-                AGG_WINDOW_POS_1_COLUMN,
-                AGG_WINDOW_POS_2_COLUMN,
-                AGG_STAT_COLUMN,
+                agg_chromosome_column,
+                agg_window_pos_1_column,
+                agg_window_pos_2_column,
+                agg_stat_column,
                 7,
                 8,
                 9,
@@ -226,10 +230,10 @@ def aggregate_output(
         outsorted = outsorted[
             [
                 1,
-                AGG_CHROMOSOME_COLUMN,
-                AGG_WINDOW_POS_1_COLUMN,
-                AGG_WINDOW_POS_2_COLUMN,
-                AGG_STAT_COLUMN,
+                agg_chromosome_column,
+                agg_window_pos_1_column,
+                agg_window_pos_2_column,
+                agg_stat_column,
                 7,
                 8,
                 9,
@@ -241,10 +245,10 @@ def aggregate_output(
             [
                 1,
                 2,
-                AGG_CHROMOSOME_COLUMN,
-                AGG_WINDOW_POS_1_COLUMN,
-                AGG_WINDOW_POS_2_COLUMN,
-                AGG_STAT_COLUMN,
+                agg_chromosome_column,
+                agg_window_pos_1_column,
+                agg_window_pos_2_column,
+                agg_stat_column,
                 7,
                 8,
                 9,

--- a/pixy/models.py
+++ b/pixy/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import fields
+from typing import Dict
 from typing import Literal
 from typing import Union
 
@@ -48,6 +49,8 @@ class PixyTempResult:
     `raw_pi` is stored in the `total_differences` field.
     `watterson_theta` is stored in the `total_comparisons` field.
     `d_stdev` is stored in the `total_missing` field.
+    `tajima_d_variant_counts` stores the internal observed-allele-count classes used to recompute
+    `d_stdev` when aggregating chunked Tajima's D output.
 
     This object is overloaded so that all `pixy` stats can leverage one dataclass to hold temporary
     results.
@@ -70,6 +73,7 @@ class PixyTempResult:
     total_differences: Union[int, float, NA]
     total_comparisons: Union[int, float, NA]
     total_missing: Union[int, float, NA]
+    tajima_d_variant_counts: Union[str, NA] = "NA"
 
     def __str__(self) -> str:
         """Returns a tab-delimited string representation for writing out to the temp file."""
@@ -166,6 +170,7 @@ class TajimaDResult:
         watterson_theta: the calculation of Watterson's theta that includes missing genotypes
         d_stdev: the denominator of Tajima's D (standard deviation of the covariance between the
             calculated raw pi and watterson_theta)
+        variant_gt_counts: count of segregating sites by number of observed alleles
     """
 
     tajima_d: Union[float, NA]
@@ -173,11 +178,19 @@ class TajimaDResult:
     raw_pi: Union[float, NA]
     watterson_theta: Union[float, NA]
     d_stdev: Union[float, NA]
+    variant_gt_counts: Dict[int, int]
 
     @classmethod
     def empty(cls) -> "TajimaDResult":
         """An empty `TajimaDResult`, with all fields set to NA."""
-        return cls(tajima_d="NA", num_sites=0, raw_pi="NA", watterson_theta="NA", d_stdev="NA")
+        return cls(
+            tajima_d="NA",
+            num_sites=0,
+            raw_pi="NA",
+            watterson_theta="NA",
+            d_stdev="NA",
+            variant_gt_counts={},
+        )
 
 
 @dataclass
@@ -194,7 +207,7 @@ class WattersonThetaResult:
     Attributes:
         num_sites: number of sites with more than zero alleles
         num_var_sites: number of variant sites
-        avg_theta: calculated as `raw_theta`/`weighted_sites`
+        avg_theta: calculated as `raw_theta`/`num_sites`
         raw_theta: per-site (unscaled) Watterson's Theta
         num_weighted_sites: number of sites weighted by how many genotypes are missing in each site
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,8 +183,10 @@ def run_pixy_helper(  # noqa: C901
     output_prefix: Optional[str] = None,
     debug: bool = False,
     cores: Optional[int] = None,
+    chunk_size: Optional[int] = None,
     fst_type: Optional[str] = None,
     fst_components: bool = False,
+    tajima_components: bool = False,
 ) -> None:
     """
     Run `pixy` with the specified arguments.
@@ -242,11 +244,17 @@ def run_pixy_helper(  # noqa: C901
     if cores is not None:
         test_args.extend((["--n_cores", f"{cores}"]))
 
+    if chunk_size is not None:
+        test_args.extend((["--chunk_size", f"{chunk_size}"]))
+
     if fst_type is not None:
         test_args.extend((["--fst_type", f"{fst_type}"]))
 
     if fst_components:
         test_args.extend(["--fst_components"])
+
+    if tajima_components:
+        test_args.extend(["--tajima_components"])
 
     if bypass_invariant_check:
         test_args.extend(["--bypass_invariant_check"])

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -6,8 +6,12 @@ from typing import List
 from typing import Optional
 from unittest.mock import patch
 
+import numpy as np
+import pandas as pd
 import pytest
 
+from pixy.calc import calc_tajima_d_stdev
+from pixy.calc import deserialize_tajima_d_variant_counts
 from tests.conftest import assert_files_are_consistent
 from tests.conftest import run_pixy_helper
 
@@ -492,6 +496,184 @@ def test_pixy_output_creation(
     for file in unexpected_files:
         full_path = pixy_out_dir / Path(f"{output_prefix}_{file}.txt")
         assert not os.path.exists(full_path)
+
+
+@pytest.mark.regression
+def test_pixy_watterson_theta_aggregation_matches_direct_calculation(
+    pixy_out_dir: Path,
+    ag1000_pop_path: Path,
+    ag1000_vcf_path: Path,
+) -> None:
+    """Chunk-aggregated Watterson's theta should match direct window calculation."""
+    shared_args = {
+        "pixy_out_dir": pixy_out_dir,
+        "stats": ["watterson_theta"],
+        "window_size": 10000,
+        "vcf_path": ag1000_vcf_path,
+        "populations_path": ag1000_pop_path,
+        "chromosomes": "X",
+        "cores": 1,
+    }
+    run_pixy_helper(
+        **shared_args,
+        output_prefix="watterson_direct",
+        chunk_size=100000,
+    )
+    run_pixy_helper(
+        **shared_args,
+        output_prefix="watterson_aggregated",
+        chunk_size=5000,
+    )
+
+    direct = pd.read_csv(pixy_out_dir / "watterson_direct_watterson_theta.txt", sep="\t")
+    aggregated = pd.read_csv(pixy_out_dir / "watterson_aggregated_watterson_theta.txt", sep="\t")
+    sort_columns = ["pop", "chromosome", "window_pos_1", "window_pos_2"]
+    direct = direct.sort_values(sort_columns).reset_index(drop=True)
+    aggregated = aggregated.sort_values(sort_columns).reset_index(drop=True)
+
+    exact_columns = sort_columns + ["no_sites", "no_var_sites"]
+    pd.testing.assert_frame_equal(direct[exact_columns], aggregated[exact_columns])
+
+    float_columns = ["avg_watterson_theta", "raw_watterson_theta", "weighted_no_sites"]
+    assert np.allclose(direct[float_columns].to_numpy(), aggregated[float_columns].to_numpy())
+    assert np.allclose(
+        aggregated["avg_watterson_theta"].to_numpy(),
+        (aggregated["raw_watterson_theta"] / aggregated["no_sites"]).to_numpy(),
+    )
+
+
+@pytest.mark.regression
+def test_pixy_tajima_d_aggregation_matches_direct_calculation(
+    pixy_out_dir: Path,
+    ag1000_pop_path: Path,
+    ag1000_vcf_path: Path,
+) -> None:
+    """Chunk-aggregated Tajima's D should match direct window calculation."""
+    shared_args = {
+        "pixy_out_dir": pixy_out_dir,
+        "stats": ["tajima_d"],
+        "window_size": 10000,
+        "vcf_path": ag1000_vcf_path,
+        "populations_path": ag1000_pop_path,
+        "chromosomes": "X",
+        "cores": 1,
+    }
+    run_pixy_helper(
+        **shared_args,
+        output_prefix="tajima_direct",
+        chunk_size=100000,
+    )
+    run_pixy_helper(
+        **shared_args,
+        output_prefix="tajima_aggregated",
+        chunk_size=5000,
+    )
+
+    direct = pd.read_csv(pixy_out_dir / "tajima_direct_tajima_d.txt", sep="\t")
+    aggregated = pd.read_csv(pixy_out_dir / "tajima_aggregated_tajima_d.txt", sep="\t")
+    assert "tajima_d_s_counts" not in direct.columns
+    assert "tajima_d_s_counts" not in aggregated.columns
+    sort_columns = ["pop", "chromosome", "window_pos_1", "window_pos_2"]
+    direct = direct.sort_values(sort_columns).reset_index(drop=True)
+    aggregated = aggregated.sort_values(sort_columns).reset_index(drop=True)
+
+    exact_columns = sort_columns + ["no_sites"]
+    pd.testing.assert_frame_equal(direct[exact_columns], aggregated[exact_columns])
+
+    float_columns = ["tajima_d", "raw_pi", "raw_watterson_theta", "tajima_d_stdev"]
+    assert np.allclose(
+        direct[float_columns].to_numpy(),
+        aggregated[float_columns].to_numpy(),
+        equal_nan=True,
+    )
+
+    valid_denominators = aggregated["tajima_d_stdev"] > 0
+    assert np.allclose(
+        aggregated.loc[valid_denominators, "tajima_d"].to_numpy(),
+        (
+            (
+                aggregated.loc[valid_denominators, "raw_pi"]
+                - aggregated.loc[valid_denominators, "raw_watterson_theta"]
+            )
+            / aggregated.loc[valid_denominators, "tajima_d_stdev"]
+        ).to_numpy(),
+    )
+
+
+@pytest.mark.regression
+def test_pixy_tajima_d_components_enable_posthoc_aggregation(
+    pixy_out_dir: Path,
+    ag1000_pop_path: Path,
+    ag1000_vcf_path: Path,
+) -> None:
+    """The --tajima_components flag should emit enough data to aggregate Tajima's D."""
+    shared_args = {
+        "pixy_out_dir": pixy_out_dir,
+        "stats": ["tajima_d"],
+        "vcf_path": ag1000_vcf_path,
+        "populations_path": ag1000_pop_path,
+        "chromosomes": "X",
+        "cores": 1,
+        "chunk_size": 100000,
+    }
+    run_pixy_helper(
+        **shared_args,
+        window_size=10000,
+        output_prefix="tajima_components_10kb",
+        tajima_components=True,
+    )
+    run_pixy_helper(
+        **shared_args,
+        window_size=20000,
+        output_prefix="tajima_direct_20kb",
+    )
+
+    components = pd.read_csv(pixy_out_dir / "tajima_components_10kb_tajima_d.txt", sep="\t")
+    direct = pd.read_csv(pixy_out_dir / "tajima_direct_20kb_tajima_d.txt", sep="\t")
+    assert "tajima_d_s_counts" in components.columns
+    assert "tajima_d_s_counts" not in direct.columns
+
+    components["posthoc_window_pos_1"] = ((components["window_pos_1"] - 1) // 20000) * 20000 + 1
+    components["posthoc_window_pos_2"] = components["posthoc_window_pos_1"] + 19999
+    group_columns = ["pop", "chromosome", "posthoc_window_pos_1", "posthoc_window_pos_2"]
+
+    posthoc_rows = []
+    for group_key, group in components.groupby(group_columns, sort=False):
+        variant_counts = {}
+        for value in group["tajima_d_s_counts"]:
+            for n, s in deserialize_tajima_d_variant_counts(value).items():
+                variant_counts[n] = variant_counts.get(n, 0) + s
+
+        raw_pi = group["raw_pi"].sum()
+        raw_watterson_theta = group["raw_watterson_theta"].sum()
+        tajima_d_stdev = calc_tajima_d_stdev(variant_counts)
+        tajima_d = (raw_pi - raw_watterson_theta) / tajima_d_stdev if tajima_d_stdev > 0 else np.nan
+        pop, chromosome, window_pos_1, window_pos_2 = group_key
+        posthoc_rows.append({
+            "pop": pop,
+            "chromosome": chromosome,
+            "window_pos_1": window_pos_1,
+            "window_pos_2": window_pos_2,
+            "tajima_d": tajima_d,
+            "no_sites": group["no_sites"].sum(),
+            "raw_pi": raw_pi,
+            "raw_watterson_theta": raw_watterson_theta,
+            "tajima_d_stdev": tajima_d_stdev,
+        })
+
+    posthoc = pd.DataFrame(posthoc_rows)
+    sort_columns = ["pop", "chromosome", "window_pos_1", "window_pos_2"]
+    posthoc = posthoc.sort_values(sort_columns).reset_index(drop=True)
+    direct = direct.sort_values(sort_columns).reset_index(drop=True)
+
+    exact_columns = sort_columns + ["no_sites"]
+    pd.testing.assert_frame_equal(direct[exact_columns], posthoc[exact_columns])
+    float_columns = ["tajima_d", "raw_pi", "raw_watterson_theta", "tajima_d_stdev"]
+    assert np.allclose(
+        direct[float_columns].to_numpy(),
+        posthoc[float_columns].to_numpy(),
+        equal_nan=True,
+    )
 
 
 ################################################################################

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -2,6 +2,8 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from unittest.mock import patch
@@ -505,7 +507,7 @@ def test_pixy_watterson_theta_aggregation_matches_direct_calculation(
     ag1000_vcf_path: Path,
 ) -> None:
     """Chunk-aggregated Watterson's theta should match direct window calculation."""
-    shared_args = {
+    shared_args: Dict[str, Any] = {
         "pixy_out_dir": pixy_out_dir,
         "stats": ["watterson_theta"],
         "window_size": 10000,
@@ -549,7 +551,7 @@ def test_pixy_tajima_d_aggregation_matches_direct_calculation(
     ag1000_vcf_path: Path,
 ) -> None:
     """Chunk-aggregated Tajima's D should match direct window calculation."""
-    shared_args = {
+    shared_args: Dict[str, Any] = {
         "pixy_out_dir": pixy_out_dir,
         "stats": ["tajima_d"],
         "window_size": 10000,
@@ -607,7 +609,7 @@ def test_pixy_tajima_d_components_enable_posthoc_aggregation(
     ag1000_vcf_path: Path,
 ) -> None:
     """The --tajima_components flag should emit enough data to aggregate Tajima's D."""
-    shared_args = {
+    shared_args: Dict[str, Any] = {
         "pixy_out_dir": pixy_out_dir,
         "stats": ["tajima_d"],
         "vcf_path": ag1000_vcf_path,
@@ -639,7 +641,7 @@ def test_pixy_tajima_d_components_enable_posthoc_aggregation(
 
     posthoc_rows = []
     for group_key, group in components.groupby(group_columns, sort=False):
-        variant_counts = {}
+        variant_counts: Dict[int, int] = {}
         for value in group["tajima_d_s_counts"]:
             for n, s in deserialize_tajima_d_variant_counts(value).items():
                 variant_counts[n] = variant_counts.get(n, 0) + s

--- a/tests/stats/test_models.py
+++ b/tests/stats/test_models.py
@@ -23,8 +23,8 @@ from pixy.models import PixyTempResult
             10,
             20,
             5,
-            "dxy\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\t20\t5",
-        ),  # no `None` -> no NA expected
+            "dxy\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\t20\t5\tNA",
+        ),  # no `None` -> only the Tajima's D temp metadata placeholder is NA
         (
             PixyStat.FST.value,
             "pop1",
@@ -37,7 +37,7 @@ from pixy.models import PixyTempResult
             "NA",
             20,
             5,
-            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\tNA\t20\t5",
+            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\tNA\t20\t5\tNA",
         ),  # `total_differences` is `None`
         (
             PixyStat.FST,
@@ -51,7 +51,7 @@ from pixy.models import PixyTempResult
             10,
             "NA",
             5,
-            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\tNA\t5",
+            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\tNA\t5\tNA",
         ),  # `total_comparisons` is `None`
         (
             PixyStat.FST,
@@ -65,7 +65,7 @@ from pixy.models import PixyTempResult
             10,
             20,
             "NA",
-            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\t20\tNA",
+            "fst\tpop1\tpop2\tchr1\t100\t200\t0.5\t50\t10\t20\tNA\tNA",
         ),  # `total_missing` is `None`
         (
             PixyStat.PI,
@@ -79,7 +79,7 @@ from pixy.models import PixyTempResult
             10,
             20,
             5,
-            "pi\tpop1\tNA\tchr1\t100\t200\t0.5\t50\t10\t20\t5",
+            "pi\tpop1\tNA\tchr1\t100\t200\t0.5\t50\t10\t20\t5\tNA",
         ),  # `population_2` is `None`
     ],
 )


### PR DESCRIPTION
Recompute aggregated Tajima's D from summed raw components and observed-allele count classes, expose those classes with --tajima_components, and document exact post-hoc aggregation recipes for each statistic.