### PR TITLE
Allow biallelic FST + multiallelic pi/dxy

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -85,6 +85,13 @@ Optional
     ``wc_fst_b``, and ``wc_fst_c``. For ``--fst_type hudson``, this
     adds ``hudson_fst_num`` and ``hudson_fst_den``.
 
+**--fst_biallelic**
+    Restrict F\ :sub:`ST` to biallelic sites, excluding multiallelic sites
+    from the F\ :sub:`ST` calculation only; they still contribute to π and
+    d\ :sub:`xy`. This only has an effect for ``--fst_type hudson`` in
+    combination with ``--include_multiallelic_snps``, since ``--fst_type wc``
+    is always restricted to biallelic sites. Disabled by default.
+
 **--tajima_components**
     Include the Tajima's *D* aggregation components in the Tajima's *D*
     output table. This adds ``tajima_d_s_counts``, a comma-separated list

--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -249,6 +249,20 @@ def main() -> None:  # noqa: C901
         required=False,
     )
     optional.add_argument(
+        "--fst_biallelic",
+        action="store_true",
+        default=False,
+        help=(
+            "Restrict FST to biallelic sites, excluding multiallelic sites from the FST "
+            "calculation only (they still contribute to pi and dxy). "
+            "This only has an effect for --fst_type hudson in combination with "
+            "--include_multiallelic_snps; --fst_type wc is always restricted to biallelic "
+            "sites regardless of this flag. "
+            "Defaults to False."
+        ),
+        required=False,
+    )
+    optional.add_argument(
         "--tajima_components",
         action="store_true",
         default=False,

--- a/pixy/args_validation.py
+++ b/pixy/args_validation.py
@@ -186,6 +186,9 @@ class PixyArgs:
         fst_type: the FST estimator to use, one of either 'WC' (Weir and Cockerham 1984) or
             'HUDSON' (Hudson 1992, Bhatia et al. 2013). Defaults to 'WC'.
         fst_components: whether to include FST estimator components in the final FST output table
+        fst_biallelic: whether to restrict FST to biallelic sites, excluding multiallelic sites
+            from the FST calculation only. Only has an effect for 'HUDSON' in combination with
+            `include_multiallelic_snps`; 'WC' is always restricted to biallelic sites.
         tajima_components: whether to include Tajima's D aggregation components in the final
             Tajima's D output table
         temp_file: a Path to which to write intermediate `pixy` results, assigned based on the value
@@ -219,6 +222,7 @@ class PixyArgs:
     num_cores: int = 1
     fst_type: FSTEstimator = FSTEstimator.WC
     fst_components: bool = False
+    fst_biallelic: bool = False
     tajima_components: bool = False
     output_prefix: str = "pixy"
     chunk_size: int = 100000
@@ -1166,6 +1170,7 @@ def check_and_validate_args(  # noqa: C901
         chunk_size=args.chunk_size,
         fst_type=FSTEstimator[args.fst_type.upper()],
         fst_components=getattr(args, "fst_components", False),
+        fst_biallelic=getattr(args, "fst_biallelic", False),
         tajima_components=getattr(args, "tajima_components", False),
         temp_file=tmp_path,
         ploidy_map=ploidy_map,

--- a/pixy/stats/summary.py
+++ b/pixy/stats/summary.py
@@ -71,10 +71,11 @@ def precompute_filtered_variant_array(
 
         # remove invariant sites, and for Weir-Cockerham also polyallelic sites
         # (`allel.weir_cockerham_fst` assumes biallelic data, whereas pixy's Hudson estimator
-        # handles any number of alleles)
+        # handles any number of alleles). --fst_biallelic opts Hudson back in to the
+        # biallelic-only behavior; it is a no-op for Weir-Cockerham, which is always biallelic.
         # we retain sites where num ALTs > 2 but only have genotypes from two alleles
         site_is_usable: NDArray[np.bool_]
-        if FSTEstimator(args.fst_type) is FSTEstimator.HUDSON:
+        if FSTEstimator(args.fst_type) is FSTEstimator.HUDSON and not args.fst_biallelic:
             site_is_usable = allele_counts.allelism()[:] > 1
         else:
             site_is_usable = allele_counts.is_biallelic()[:]

--- a/tests/stats/test_summary.py
+++ b/tests/stats/test_summary.py
@@ -19,21 +19,30 @@ POS_ARRAY = SortedIndex(np.array([100, 200, 300]))
 
 
 @pytest.mark.parametrize(
-    "fst_type, expected_positions",
+    "fst_type, fst_biallelic, expected_positions",
     [
         # Weir-Cockerham assumes biallelic data, so multiallelic sites are dropped
-        (FSTEstimator.WC, [200]),
+        (FSTEstimator.WC, False, [200]),
         # pixy's Hudson estimator handles any number of alleles, so only the invariant site is
         # dropped
-        (FSTEstimator.HUDSON, [200, 300]),
+        (FSTEstimator.HUDSON, False, [200, 300]),
+        # --fst_biallelic opts Hudson back in to biallelic-only filtering
+        (FSTEstimator.HUDSON, True, [200]),
+        # ...and is a no-op for Weir-Cockerham, which is always biallelic
+        (FSTEstimator.WC, True, [200]),
     ],
 )
 def test_precompute_filtered_variant_array_retains_multiallelic_sites_for_hudson_only(
     fst_type: FSTEstimator,
+    fst_biallelic: bool,
     expected_positions: list,
 ) -> None:
-    """Multiallelic sites should be retained for Hudson FST, but not for Weir-Cockerham FST."""
-    args = argparse.Namespace(populations="populations.txt", fst_type=fst_type.value)
+    """Multiallelic sites should be retained only for Hudson FST without --fst_biallelic."""
+    args = argparse.Namespace(
+        populations="populations.txt",
+        fst_type=fst_type.value,
+        fst_biallelic=fst_biallelic,
+    )
 
     _, gt_array_fst, pos_array_fst = precompute_filtered_variant_array(
         args=args,


### PR DESCRIPTION
- add the --fst_biallelic flag to allow biallelic FST + multiallelic pi/dxy
- this allows users to avoid the homoplasy issue with FST, while getting the benefits of unbiased pi/dxy