### PR TITLE
fix version display inconsistencies

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,6 +1,19 @@
 name: Code checks
 
-on: [push, pull_request]
+# `push` is limited to master because a PR branch in this repo would otherwise fire
+# both `push` and `pull_request` for the same commit, queueing two identical runs of
+# the five-way Python matrix. Branch pushes are still covered — via `pull_request`
+# once a PR is open.
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Superseded runs are pointless once a newer commit exists on the same ref, and they
+# hold runners that the newest commit is waiting on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   POETRY_VERSION: 1.8.5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ====================
 
 [![Install with Conda](https://img.shields.io/badge/Install%20with-conda-brightgreen.svg)](https://anaconda.org/conda-forge/pixy)
-[![Anaconda Version](https://img.shields.io/badge/Anaconda.org-2.2.1-blue.svg?style=round-square)](https://anaconda.org/conda-forge/pixy)
+[![Anaconda Version](https://img.shields.io/badge/Anaconda.org-2.2.3-blue.svg?style=round-square)](https://anaconda.org/conda-forge/pixy)
 [![Anaconda Date](https://img.shields.io/badge/Last%20updated-24%20May%202026-blue.svg?style=round-square)](https://anaconda.org/conda-forge/pixy)
 [![Anaconda Platforms](https://img.shields.io/badge/Platforms-osx--arm64,linux--64,osx--64-orange.svg?style=round-square)](https://anaconda.org/conda-forge/pixy)
 [![Python Versions](https://img.shields.io/badge/python-3.10_|_3.11_|_3.12_|_3.13_|_3.14-blue)](https://github.com/ksamuk/pixy)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "pixy" %}
-{% set version = "2.2.1" %}
+{# version is read from pyproject.toml so it is only ever declared in one place.
+   from_recipe_dir=True makes the path resolve relative to this recipe rather than
+   the (not-yet-populated) source work dir. #}
+{% set version = load_file_data('../pyproject.toml', from_recipe_dir=True)['tool']['poetry']['version'] %}
 
 package:
   name: {{ name|lower }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,15 @@ Explanations of major changes to ``pixy`` are listed below. For up-to-date
 info on minor versions and bugfixes, see the release notes on GitHub:
 https://github.com/ksamuk/pixy/releases
 
-Unreleased
+pixy 2.2.3
 ==========
+
+This release contains the same analytical changes as the 2.2.2 tag, which
+was released with its internal version strings left at ``2.2.1``: builds
+from that tag report ``pixy 2.2.1`` from ``pixy --version`` and in output
+headers. 2.2.3 corrects the version strings only; if you are on 2.2.2,
+there is no change in results, but ``--version`` will now agree with the
+release you installed.
 
 New features
 ------------
@@ -88,7 +95,7 @@ Bug fixes
   parsimony minimum, so θ\ :sub:`W` retains a small (~4%) downward bias
   that no model-free estimator can remove.
 
-pixy 2.1.3
+pixy 2.2.0
 ==========
 
 New features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,9 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from pathlib import Path
+
+import tomllib
 
 # -- Project information -----------------------------------------------------
 
@@ -23,10 +26,15 @@ project = "pixy"
 copyright = "2019-2026, Kieran Samuk, Katharine Korunes"
 author = "Kieran Samuk, Katharine Korunes"
 
-# The short X.Y version
-version = "2.0"
+# Read the version from pyproject.toml rather than duplicating it here. Read the Docs
+# builds the docs without installing pixy, so importlib.metadata is not an option.
+with (Path(__file__).parent.parent / "pyproject.toml").open("rb") as pyproject:
+    _version = tomllib.load(pyproject)["tool"]["poetry"]["version"]
+
 # The full version, including alpha/beta/rc tags
-release = "2.0.0"
+release = _version
+# The short X.Y version
+version = ".".join(_version.split(".")[:2])
 
 
 # -- General configuration ---------------------------------------------------

--- a/pixy/__main__.py
+++ b/pixy/__main__.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 import time
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import List
@@ -40,7 +41,9 @@ def main() -> None:  # noqa: C901
         "pixy: unbiased estimates of pi, dxy, fst, Watterson's Theta, and Tajima's D from "
         "VCFs with invariant sites"
     )
-    version = "2.2.1"
+    # single source of truth is the `version` field of pyproject.toml, recorded in the
+    # installed package metadata at build time
+    version = package_version("pixy")
     citation = (
         "Korunes, KL and K Samuk. "
         "pixy: Unbiased estimation of nucleotide diversity and divergence in the presence of "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "pixy"
-version       = "2.2.1"
+version       = "2.2.3"
 description   = "An unbiased estimation of average nucleotide diversity within (π) and between (dxy) populations from a VCF"
 readme        = "README.md"
 authors       = [


### PR DESCRIPTION
- version string in help/docs is now dynamically built vs. hardcoded (mangled in last few releases, a long standing issue)